### PR TITLE
Don't profile command buffers executed on transfer queues

### DIFF
--- a/VkLayer_profiler_layer/profiler/CMakeLists.txt
+++ b/VkLayer_profiler_layer/profiler/CMakeLists.txt
@@ -25,6 +25,7 @@ project (profiler)
 set (headers
     "profiler.h"
     "profiler_command_buffer.h"
+    "profiler_command_pool.h"
     "profiler_counters.h"
     "profiler_data.h"
     "profiler_data_aggregator.h"
@@ -37,6 +38,7 @@ set (headers
 set (sources
     "profiler.cpp"
     "profiler_command_buffer.cpp"
+    "profiler_command_pool.cpp"
     "profiler_data_aggregator.cpp"
     # Windows
     "profiler_helpers_windows.cpp"

--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -145,8 +145,8 @@ namespace Profiler
         ConcurrentMap<VkDeviceMemory, VkMemoryAllocateInfo> m_Allocations;
         DeviceProfilerMemoryData m_MemoryData;
 
-        ConcurrentMap<VkCommandBuffer, ProfilerCommandBuffer> m_CommandBuffers;
-        ConcurrentMap<VkCommandPool, DeviceProfilerCommandPool> m_CommandPools;
+        ConcurrentMap<VkCommandBuffer, std::unique_ptr<ProfilerCommandBuffer>> m_pCommandBuffers;
+        ConcurrentMap<VkCommandPool, std::unique_ptr<DeviceProfilerCommandPool>> m_pCommandPools;
 
         ConcurrentMap<VkShaderModule, uint32_t> m_ShaderModuleHashes;
         ConcurrentMap<VkPipeline, DeviceProfilerPipeline> m_Pipelines;
@@ -169,8 +169,8 @@ namespace Profiler
 
         void SetDefaultObjectName( const DeviceProfilerPipeline& pipeline );
 
-        decltype(m_CommandBuffers)::iterator FreeCommandBuffer( VkCommandBuffer );
-        decltype(m_CommandBuffers)::iterator FreeCommandBuffer( decltype(m_CommandBuffers)::iterator );
+        decltype(m_pCommandBuffers)::iterator FreeCommandBuffer( VkCommandBuffer );
+        decltype(m_pCommandBuffers)::iterator FreeCommandBuffer( decltype(m_pCommandBuffers)::iterator );
     };
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "profiler_counters.h"
+#include "profiler_command_pool.h"
 #include "profiler_data_aggregator.h"
 #include "profiler_helpers.h"
 #include "profiler_data.h"
@@ -87,8 +88,12 @@ namespace Profiler
         DeviceProfilerFrameData GetData() const;
 
         ProfilerCommandBuffer& GetCommandBuffer( VkCommandBuffer commandBuffer );
+        DeviceProfilerCommandPool& GetCommandPool( VkCommandPool commandPool );
         DeviceProfilerPipeline& GetPipeline( VkPipeline pipeline );
         DeviceProfilerRenderPass& GetRenderPass( VkRenderPass renderPass );
+
+        void CreateCommandPool( VkCommandPool, const VkCommandPoolCreateInfo* );
+        void DestroyCommandPool( VkCommandPool );
 
         void AllocateCommandBuffers( VkCommandPool, VkCommandBufferLevel, uint32_t, VkCommandBuffer* );
         void FreeCommandBuffers( uint32_t, const VkCommandBuffer* );
@@ -142,6 +147,7 @@ namespace Profiler
         DeviceProfilerMemoryData m_MemoryData;
 
         ConcurrentMap<VkCommandBuffer, ProfilerCommandBuffer> m_CommandBuffers;
+        ConcurrentMap<VkCommandPool, DeviceProfilerCommandPool> m_CommandPools;
 
         ConcurrentMap<VkShaderModule, uint32_t> m_ShaderModuleHashes;
         ConcurrentMap<VkPipeline, DeviceProfilerPipeline> m_Pipelines;

--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -97,7 +97,6 @@ namespace Profiler
 
         void AllocateCommandBuffers( VkCommandPool, VkCommandBufferLevel, uint32_t, VkCommandBuffer* );
         void FreeCommandBuffers( uint32_t, const VkCommandBuffer* );
-        void FreeCommandBuffers( VkCommandPool );
 
         void CreatePipelines( uint32_t, const VkGraphicsPipelineCreateInfo*, VkPipeline* );
         void CreatePipelines( uint32_t, const VkComputePipelineCreateInfo*, VkPipeline* );

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
@@ -53,12 +53,13 @@ namespace Profiler
         Constructor.
 
     \***********************************************************************************/
-    ProfilerCommandBuffer::ProfilerCommandBuffer( DeviceProfiler& profiler, VkCommandPool commandPool, VkCommandBuffer commandBuffer, VkCommandBufferLevel level )
+    ProfilerCommandBuffer::ProfilerCommandBuffer( DeviceProfiler& profiler, DeviceProfilerCommandPool& commandPool, VkCommandBuffer commandBuffer, VkCommandBufferLevel level )
         : m_Profiler( profiler )
         , m_CommandPool( commandPool )
         , m_CommandBuffer( commandBuffer )
         , m_Level( level )
         , m_Dirty( false )
+        , m_ProfilingEnabled( true )
         , m_SecondaryCommandBuffers()
         , m_QueryPools()
         , m_QueryPoolSize( 4096 )
@@ -76,8 +77,17 @@ namespace Profiler
         m_Data.m_Handle = commandBuffer;
         m_Data.m_Level = level;
 
+        // Profile the command buffer only if it will be submitted to the queue supporting graphics or compute commands
+        // This is requirement of vkCmdResetQueryPool (VUID-vkCmdResetQueryPool-commandBuffer-cmdpool)
+        if( (m_CommandPool.GetCommandQueueFlags() & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)) == 0 )
+        {
+            m_ProfilingEnabled = false;
+        }
+
         // Initialize performance query once
-        if( (m_Level == VK_COMMAND_BUFFER_LEVEL_PRIMARY) && (m_Profiler.m_MetricsApiINTEL.IsAvailable()) )
+        if( (m_ProfilingEnabled) &&
+            (m_Level == VK_COMMAND_BUFFER_LEVEL_PRIMARY) &&
+            (m_Profiler.m_MetricsApiINTEL.IsAvailable()) )
         {
             VkQueryPoolCreateInfoINTEL intelCreateInfo = {};
             intelCreateInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO_INTEL;
@@ -110,6 +120,13 @@ namespace Profiler
     \***********************************************************************************/
     ProfilerCommandBuffer::~ProfilerCommandBuffer()
     {
+        // Destroy performance query pool
+        if( m_PerformanceQueryPoolINTEL )
+        {
+            m_Profiler.m_pDevice->Callbacks.DestroyQueryPool(
+                m_Profiler.m_pDevice->Handle, m_PerformanceQueryPoolINTEL, nullptr );
+        }
+
         // Destroy allocated query pools
         for( auto& pool : m_QueryPools )
         {
@@ -129,7 +146,7 @@ namespace Profiler
         Returns VkCommandPool object associated with this instance.
 
     \***********************************************************************************/
-    VkCommandPool ProfilerCommandBuffer::GetCommandPool() const
+    DeviceProfilerCommandPool& ProfilerCommandBuffer::GetCommandPool() const
     {
         return m_CommandPool;
     }
@@ -143,7 +160,7 @@ namespace Profiler
         Returns VkCommandBuffer object associated with this instance.
 
     \***********************************************************************************/
-    VkCommandBuffer ProfilerCommandBuffer::GetCommandBuffer() const
+    VkCommandBuffer ProfilerCommandBuffer::GetHandle() const
     {
         return m_CommandBuffer;
     }
@@ -159,8 +176,11 @@ namespace Profiler
     \***********************************************************************************/
     void ProfilerCommandBuffer::Submit()
     {
-        // Contents of the command buffer did not change, but all queries will be executed again
-        m_Dirty = true;
+        if( m_ProfilingEnabled )
+        {
+            // Contents of the command buffer did not change, but all queries will be executed again
+            m_Dirty = true;
+        }
 
         // Secondary command buffers will be executed as well
         for( VkCommandBuffer commandBuffer : m_SecondaryCommandBuffers )
@@ -191,11 +211,14 @@ namespace Profiler
         }
         else
         {
-            // Reset existing query pool to reuse the queries
-            m_Profiler.m_pDevice->Callbacks.CmdResetQueryPool(
-                m_CommandBuffer,
-                m_QueryPools.front(),
-                0, m_QueryPoolSize );
+            if( m_ProfilingEnabled )
+            {
+                // Reset existing query pool to reuse the queries
+                m_Profiler.m_pDevice->Callbacks.CmdResetQueryPool(
+                    m_CommandBuffer,
+                    m_QueryPools.front(),
+                    0, m_QueryPoolSize );
+            }
         }
 
         // Move to the first query pool
@@ -210,6 +233,8 @@ namespace Profiler
         // Begin collection of vendor metrics
         if( m_PerformanceQueryPoolINTEL )
         {
+            assert( m_ProfilingEnabled );
+
             m_Profiler.m_pDevice->Callbacks.CmdResetQueryPool(
                 m_CommandBuffer,
                 m_PerformanceQueryPoolINTEL, 0, 1 );
@@ -239,6 +264,8 @@ namespace Profiler
 
         if( m_PerformanceQueryPoolINTEL )
         {
+            assert( m_ProfilingEnabled );
+
             m_Profiler.m_pDevice->Callbacks.CmdEndQuery(
                 m_CommandBuffer,
                 m_PerformanceQueryPoolINTEL, 0 );
@@ -743,28 +770,33 @@ namespace Profiler
     \***********************************************************************************/
     void ProfilerCommandBuffer::AllocateQueryPool()
     {
-        VkQueryPool queryPool = VK_NULL_HANDLE;
-
-        VkQueryPoolCreateInfo info = {};
-        info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
-        info.queryType = VK_QUERY_TYPE_TIMESTAMP;
-        info.queryCount = m_QueryPoolSize;
-
-        // Allocate new query pool
-        VkResult result = m_Profiler.m_pDevice->Callbacks.CreateQueryPool(
-            m_Profiler.m_pDevice->Handle, &info, nullptr, &queryPool );
-
-        if( result != VK_SUCCESS )
+        // Allocate new query pool only if the command buffer can reset it
+        // (see VUID-vkCmdResetQueryPool-commandBuffer-cmdpool)
+        if( m_ProfilingEnabled )
         {
-            // Allocation failed
-            return;
+            VkQueryPool queryPool = VK_NULL_HANDLE;
+
+            VkQueryPoolCreateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+            info.queryType = VK_QUERY_TYPE_TIMESTAMP;
+            info.queryCount = m_QueryPoolSize;
+
+            // Allocate new query pool
+            VkResult result = m_Profiler.m_pDevice->Callbacks.CreateQueryPool(
+                m_Profiler.m_pDevice->Handle, &info, nullptr, &queryPool );
+
+            if( result != VK_SUCCESS )
+            {
+                // Allocation failed
+                return;
+            }
+
+            // Pools must be reset before first use
+            m_Profiler.m_pDevice->Callbacks.CmdResetQueryPool(
+                m_CommandBuffer, queryPool, 0, m_QueryPoolSize );
+
+            m_QueryPools.push_back( queryPool );
         }
-
-        // Pools must be reset before first use
-        m_Profiler.m_pDevice->Callbacks.CmdResetQueryPool(
-            m_CommandBuffer, queryPool, 0, m_QueryPoolSize );
-
-        m_QueryPools.push_back( queryPool );
     }
 
     /***********************************************************************************\
@@ -846,31 +878,35 @@ namespace Profiler
     \***********************************************************************************/
     void ProfilerCommandBuffer::SendTimestampQuery( VkPipelineStageFlagBits stage )
     {
-        // Allocate query from the pool
-        m_CurrentQueryIndex++;
-
-        if( m_CurrentQueryIndex == m_QueryPoolSize )
+        // Send timestamp queries only if profiling has been enabled for this command buffer
+        if( m_ProfilingEnabled )
         {
-            // Try to reuse next query pool
-            m_CurrentQueryIndex = 0;
-            m_CurrentQueryPoolIndex++;
+            // Allocate query from the pool
+            m_CurrentQueryIndex++;
 
-            if( m_CurrentQueryPoolIndex == m_QueryPools.size() )
+            if( m_CurrentQueryIndex == m_QueryPoolSize )
             {
-                // If command buffer is not in render pass we must allocate next query pool now
-                // Otherwise something went wrong in PreBeginRenderPass
-                assert( !m_pCurrentRenderPass );
+                // Try to reuse next query pool
+                m_CurrentQueryIndex = 0;
+                m_CurrentQueryPoolIndex++;
 
-                AllocateQueryPool();
+                if( m_CurrentQueryPoolIndex == m_QueryPools.size() )
+                {
+                    // If command buffer is not in render pass we must allocate next query pool now
+                    // Otherwise something went wrong in PreBeginRenderPass
+                    assert( !m_pCurrentRenderPass );
+
+                    AllocateQueryPool();
+                }
             }
-        }
 
-        // Send the query
-        m_Profiler.m_pDevice->Callbacks.CmdWriteTimestamp(
-            m_CommandBuffer,
-            stage,
-            m_QueryPools[m_CurrentQueryPoolIndex],
-            m_CurrentQueryIndex );
+            // Send the query
+            m_Profiler.m_pDevice->Callbacks.CmdWriteTimestamp(
+                m_CommandBuffer,
+                stage,
+                m_QueryPools[ m_CurrentQueryPoolIndex ],
+                m_CurrentQueryIndex );
+        }
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
@@ -186,7 +186,7 @@ namespace Profiler
         for( VkCommandBuffer commandBuffer : m_SecondaryCommandBuffers )
         {
             // Use direct access - m_CommandBuffers map is already locked
-            m_Profiler.m_CommandBuffers.at( commandBuffer ).Submit();
+            m_Profiler.m_pCommandBuffers.at( commandBuffer )->Submit();
         }
     }
 
@@ -682,7 +682,7 @@ namespace Profiler
                             for( auto& commandBuffer : subpass.m_SecondaryCommandBuffers )
                             {
                                 VkCommandBuffer handle = commandBuffer.m_Handle;
-                                ProfilerCommandBuffer& profilerCommandBuffer = m_Profiler.m_CommandBuffers.unsafe_at( handle );
+                                ProfilerCommandBuffer& profilerCommandBuffer = *m_Profiler.m_pCommandBuffers.unsafe_at( handle );
 
                                 // Collect secondary command buffer data
                                 commandBuffer = profilerCommandBuffer.GetData();

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
@@ -45,6 +45,8 @@ namespace Profiler
         ProfilerCommandBuffer( DeviceProfiler&, DeviceProfilerCommandPool&, VkCommandBuffer, VkCommandBufferLevel );
         ~ProfilerCommandBuffer();
 
+        ProfilerCommandBuffer( const ProfilerCommandBuffer& ) = delete;
+
         DeviceProfilerCommandPool& GetCommandPool() const;
         VkCommandBuffer GetHandle() const;
 

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
@@ -28,6 +28,7 @@
 namespace Profiler
 {
     class DeviceProfiler;
+    class DeviceProfilerCommandPool;
 
     /***********************************************************************************\
 
@@ -41,11 +42,11 @@ namespace Profiler
     class ProfilerCommandBuffer
     {
     public:
-        ProfilerCommandBuffer( DeviceProfiler&, VkCommandPool, VkCommandBuffer, VkCommandBufferLevel );
+        ProfilerCommandBuffer( DeviceProfiler&, DeviceProfilerCommandPool&, VkCommandBuffer, VkCommandBufferLevel );
         ~ProfilerCommandBuffer();
 
-        VkCommandPool GetCommandPool() const;
-        VkCommandBuffer GetCommandBuffer() const;
+        DeviceProfilerCommandPool& GetCommandPool() const;
+        VkCommandBuffer GetHandle() const;
 
         void Submit();
 
@@ -75,11 +76,12 @@ namespace Profiler
 
     protected:
         DeviceProfiler& m_Profiler;
+        DeviceProfilerCommandPool& m_CommandPool;
 
-        const VkCommandPool   m_CommandPool;
         const VkCommandBuffer m_CommandBuffer;
         const VkCommandBufferLevel m_Level;
 
+        bool            m_ProfilingEnabled;
         bool            m_Dirty;
 
         std::unordered_set<VkCommandBuffer> m_SecondaryCommandBuffers;

--- a/VkLayer_profiler_layer/profiler/profiler_command_pool.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_pool.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2019-2021 Lukasz Stalmirski
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "profiler_command_pool.h"
+#include "profiler.h"
+
+namespace Profiler
+{
+    /***********************************************************************************\
+
+    Function:
+        DeviceProfilerCommandPool
+
+    Description:
+        Constructor.
+
+    \***********************************************************************************/
+    DeviceProfilerCommandPool::DeviceProfilerCommandPool( DeviceProfiler& profiler, VkCommandPool commandPool, const VkCommandPoolCreateInfo& createInfo )
+        : m_CommandPool( commandPool )
+        , m_CommandQueueFlags( 0 )
+    {
+        // Get target command queue family properties
+        const VkQueueFamilyProperties& queueFamilyProperties =
+            profiler.m_pDevice->pPhysicalDevice->QueueFamilyProperties[ createInfo.queueFamilyIndex ];
+
+        m_CommandQueueFlags = queueFamilyProperties.queueFlags;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        GetHandle
+
+    Description:
+        Get command pool handle.
+
+    \***********************************************************************************/
+    VkCommandPool DeviceProfilerCommandPool::GetHandle() const
+    {
+        return m_CommandPool;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        GetCommandQueueFlags
+
+    Description:
+        Get flags of target command queue.
+
+    \***********************************************************************************/
+    VkQueueFlags DeviceProfilerCommandPool::GetCommandQueueFlags() const
+    {
+        return m_CommandQueueFlags;
+    }
+}

--- a/VkLayer_profiler_layer/profiler/profiler_command_pool.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_pool.h
@@ -37,6 +37,8 @@ namespace Profiler
     public:
         DeviceProfilerCommandPool( class DeviceProfiler&, VkCommandPool, const VkCommandPoolCreateInfo& );
 
+        DeviceProfilerCommandPool( const DeviceProfilerCommandPool& ) = delete;
+
         VkCommandPool GetHandle() const;
         VkQueueFlags GetCommandQueueFlags() const;
 

--- a/VkLayer_profiler_layer/profiler/profiler_command_pool.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_pool.h
@@ -19,41 +19,29 @@
 // SOFTWARE.
 
 #pragma once
-#include "vk_dispatch_tables.h"
-#include "VkInstance_object.h"
-#include "VkPhysicalDevice_object.h"
-#include "VkQueue_object.h"
-#include "VkSwapchainKhr_object.h"
-#include "VkObject.h"
-#include <map>
-#include <vector>
+#include <vulkan/vulkan.h>
 
 namespace Profiler
 {
-    struct VkDevice_debug_Object
+    /***********************************************************************************\
+
+    Class:
+        DeviceProfilerCommandPool
+
+    Description:
+        Wrapper for VkCommandPool object.
+
+    \***********************************************************************************/
+    class DeviceProfilerCommandPool
     {
-        std::unordered_map<VkObject, std::string> ObjectNames;
-    };
+    public:
+        DeviceProfilerCommandPool( class DeviceProfiler&, VkCommandPool, const VkCommandPoolCreateInfo& );
 
-    struct VkDevice_Object
-    {
-        VkDevice Handle;
+        VkCommandPool GetHandle() const;
+        VkQueueFlags GetCommandQueueFlags() const;
 
-        VkInstance_Object* pInstance;
-        VkPhysicalDevice_Object* pPhysicalDevice;
-
-        // Dispatch tables
-        VkLayerDeviceDispatchTable Callbacks;
-        PFN_vkSetDeviceLoaderData SetDeviceLoaderData;
-
-        VkDevice_debug_Object Debug;
-
-        std::unordered_map<VkQueue, VkQueue_Object> Queues;
-
-        // Enabled extensions
-        std::unordered_set<std::string> EnabledExtensions;
-
-        // Swapchains created with this device
-        std::unordered_map<VkSwapchainKHR, VkSwapchainKhr_Object> Swapchains;
+    private:
+        VkCommandPool m_CommandPool;
+        VkQueueFlags  m_CommandQueueFlags;
     };
 }

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -94,7 +94,7 @@ namespace Profiler
         eResolveImage = 0x000A0000,
         eBlitImage = 0x000B0000,
         eFillBuffer = 0x000C0000,
-        eUpdatBuffer = 0x000D0000,
+        eUpdateBuffer = 0x000D0000,
         eBeginRenderPass = 0x000BFFFF,
         eEndRenderPass = 0x000EFFFF
     };

--- a/VkLayer_profiler_layer/profiler_ext/VkProfilerEXT.cpp
+++ b/VkLayer_profiler_layer/profiler_ext/VkProfilerEXT.cpp
@@ -354,7 +354,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetProfilerFrameDataEXT(
         if( !data.m_Submits.empty() )
         {
             // Serialize last frame
-            result = RegionBuilder( dd.Device.Properties.limits.timestampPeriod )
+            result = RegionBuilder( dd.Device.pPhysicalDevice->Properties.limits.timestampPeriod )
                 .SerializeFrame( data, pData->frame );
         }
         else

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.cpp
@@ -435,7 +435,6 @@ namespace Profiler
         auto& dd = DeviceDispatch.Get( device );
 
         // Cleanup profiler resources associated with the command pool
-        dd.Profiler.FreeCommandBuffers( commandPool );
         dd.Profiler.DestroyCommandPool( commandPool );
 
         // Destroy the command pool

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.cpp
@@ -60,6 +60,7 @@ namespace Profiler
                 GETPROCADDR( CreateRenderPass );
                 GETPROCADDR( CreateRenderPass2 );
                 GETPROCADDR( DestroyRenderPass );
+                GETPROCADDR( CreateCommandPool );
                 GETPROCADDR( DestroyCommandPool );
                 GETPROCADDR( AllocateCommandBuffers );
                 GETPROCADDR( FreeCommandBuffers );
@@ -392,6 +393,35 @@ namespace Profiler
     /***********************************************************************************\
 
     Function:
+        CreateCommandPool
+
+    Description:
+
+    \***********************************************************************************/
+    VKAPI_ATTR VkResult VKAPI_CALL VkDevice_Functions::CreateCommandPool(
+        VkDevice device,
+        const VkCommandPoolCreateInfo* pCreateInfo,
+        const VkAllocationCallbacks* pAllocator,
+        VkCommandPool* pCommandPool )
+    {
+        auto& dd = DeviceDispatch.Get( device );
+
+        // Create the command pool
+        VkResult result = dd.Device.Callbacks.CreateCommandPool(
+            device, pCreateInfo, pAllocator, pCommandPool );
+
+        if( result == VK_SUCCESS )
+        {
+            // Create command pool wrapper
+            dd.Profiler.CreateCommandPool( *pCommandPool, pCreateInfo );
+        }
+
+        return result;
+    }
+
+    /***********************************************************************************\
+
+    Function:
         DestroyCommandPool
 
     Description:
@@ -406,6 +436,7 @@ namespace Profiler
 
         // Cleanup profiler resources associated with the command pool
         dd.Profiler.FreeCommandBuffers( commandPool );
+        dd.Profiler.DestroyCommandPool( commandPool );
 
         // Destroy the command pool
         dd.Device.Callbacks.DestroyCommandPool(

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.h
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.h
@@ -116,6 +116,13 @@ namespace Profiler
             VkRenderPass renderPass,
             const VkAllocationCallbacks* pAllocator );
 
+        // vkCreateCommandPool
+        static VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
+            VkDevice device,
+            const VkCommandPoolCreateInfo* pCreateInfo,
+            const VkAllocationCallbacks* pAllocator,
+            VkCommandPool* pCommandPool );
+
         // vkDestroyCommandPool
         static VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
             VkDevice device,

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions_base.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions_base.cpp
@@ -58,31 +58,13 @@ namespace Profiler
 
         dd.Device.Handle = device;
         dd.Device.pInstance = &id.Instance;
-        dd.Device.PhysicalDevice = physicalDevice;
-
-        // Get device properties
-        id.Instance.Callbacks.GetPhysicalDeviceProperties(
-            physicalDevice, &dd.Device.Properties );
-
-        id.Instance.Callbacks.GetPhysicalDeviceMemoryProperties(
-            physicalDevice, &dd.Device.MemoryProperties );
-
-        dd.Device.VendorID = VkDevice_Vendor_ID( dd.Device.Properties.vendorID );
+        dd.Device.pPhysicalDevice = &id.Instance.PhysicalDevices[ physicalDevice ];
 
         // Save enabled extensions
         for( uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; ++i )
         {
             dd.Device.EnabledExtensions.insert( pCreateInfo->ppEnabledExtensionNames[ i ] );
         }
-
-        // Enumerate queue families
-        uint32_t queueFamilyPropertyCount = 0;
-        id.Instance.Callbacks.GetPhysicalDeviceQueueFamilyProperties(
-            physicalDevice, &queueFamilyPropertyCount, nullptr );
-
-        std::vector<VkQueueFamilyProperties> queueFamilyProperties( queueFamilyPropertyCount );
-        id.Instance.Callbacks.GetPhysicalDeviceQueueFamilyProperties(
-            physicalDevice, &queueFamilyPropertyCount, queueFamilyProperties.data() );
 
         // Create wrapper for each device queue
         for( uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i )
@@ -91,7 +73,7 @@ namespace Profiler
                 pCreateInfo->pQueueCreateInfos[ i ];
 
             const VkQueueFamilyProperties& queueProperties =
-                queueFamilyProperties[ queueCreateInfo.queueFamilyIndex ];
+                dd.Device.pPhysicalDevice->QueueFamilyProperties[ queueCreateInfo.queueFamilyIndex ];
 
             for( uint32_t queueIndex = 0; queueIndex < queueCreateInfo.queueCount; ++queueIndex )
             {

--- a/VkLayer_profiler_layer/profiler_layer_objects/VkInstance_object.h
+++ b/VkLayer_profiler_layer/profiler_layer_objects/VkInstance_object.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "vk_dispatch_tables.h"
+#include "VkPhysicalDevice_object.h"
 #include "VkSurfaceKhr_object.h"
 #include <unordered_map>
 #include <unordered_set>
@@ -41,6 +42,9 @@ namespace Profiler
 
         // Enabled extensions
         std::unordered_set<std::string> EnabledExtensions;
+
+        // Physical devices enumerated by this instance
+        std::unordered_map<VkPhysicalDevice, VkPhysicalDevice_Object> PhysicalDevices;
 
         // Surfaces created with this instance
         std::unordered_map<VkSurfaceKHR, VkSurfaceKhr_Object> Surfaces;

--- a/VkLayer_profiler_layer/profiler_layer_objects/VkPhysicalDevice_object.h
+++ b/VkLayer_profiler_layer/profiler_layer_objects/VkPhysicalDevice_object.h
@@ -20,40 +20,29 @@
 
 #pragma once
 #include "vk_dispatch_tables.h"
-#include "VkInstance_object.h"
-#include "VkPhysicalDevice_object.h"
-#include "VkQueue_object.h"
-#include "VkSwapchainKhr_object.h"
-#include "VkObject.h"
-#include <map>
 #include <vector>
 
 namespace Profiler
 {
-    struct VkDevice_debug_Object
+    enum class VkPhysicalDevice_Vendor_ID
     {
-        std::unordered_map<VkObject, std::string> ObjectNames;
+        eUnknown = 0,
+        eAMD = 0x1002,
+        eARM = 0x13B3,
+        eINTEL = 0x8086,
+        eNV = 0x10DE,
+        eQualcomm = 0x5143
     };
 
-    struct VkDevice_Object
+    struct VkPhysicalDevice_Object
     {
-        VkDevice Handle;
+        VkPhysicalDevice Handle = VK_NULL_HANDLE;
 
-        VkInstance_Object* pInstance;
-        VkPhysicalDevice_Object* pPhysicalDevice;
+        VkPhysicalDeviceProperties Properties;
+        VkPhysicalDeviceMemoryProperties MemoryProperties;
 
-        // Dispatch tables
-        VkLayerDeviceDispatchTable Callbacks;
-        PFN_vkSetDeviceLoaderData SetDeviceLoaderData;
+        VkPhysicalDevice_Vendor_ID VendorID;
 
-        VkDevice_debug_Object Debug;
-
-        std::unordered_map<VkQueue, VkQueue_Object> Queues;
-
-        // Enabled extensions
-        std::unordered_set<std::string> EnabledExtensions;
-
-        // Swapchains created with this device
-        std::unordered_map<VkSwapchainKHR, VkSwapchainKhr_Object> Swapchains;
+        std::vector<VkQueueFamilyProperties> QueueFamilyProperties;
     };
 }

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -181,7 +181,7 @@ namespace Profiler
         // Get timestamp query period
         if( result == VK_SUCCESS )
         {
-            m_TimestampPeriod = Nanoseconds( m_pDevice->Properties.limits.timestampPeriod );
+            m_TimestampPeriod = Nanoseconds( m_pDevice->pPhysicalDevice->Properties.limits.timestampPeriod );
         }
 
         // Create swapchain-dependent resources
@@ -749,7 +749,7 @@ namespace Profiler
         m_pImGuiWindowContext->UpdateWindowRect();
 
         // GPU properties
-        ImGui::Text( "%s: %s", Lang::Device, m_pDevice->Properties.deviceName );
+        ImGui::Text( "%s: %s", Lang::Device, m_pDevice->pPhysicalDevice->Properties.deviceName );
 
         ImGuiX::TextAlignRight( "Vulkan %u.%u",
             VK_VERSION_MAJOR( m_pDevice->pInstance->ApplicationInfo.apiVersion ),
@@ -1026,7 +1026,7 @@ namespace Profiler
             imGuiInitInfo.QueueFamily = m_pGraphicsQueue->Family;
 
             imGuiInitInfo.Instance = m_pDevice->pInstance->Handle;
-            imGuiInitInfo.PhysicalDevice = m_pDevice->PhysicalDevice;
+            imGuiInitInfo.PhysicalDevice = m_pDevice->pPhysicalDevice->Handle;
             imGuiInitInfo.Device = m_pDevice->Handle;
 
             imGuiInitInfo.pInstanceDispatchTable = &m_pDevice->pInstance->Callbacks;
@@ -1447,7 +1447,7 @@ namespace Profiler
     void ProfilerOverlayOutput::UpdateMemoryTab()
     {
         const VkPhysicalDeviceMemoryProperties& memoryProperties =
-            m_pDevice->MemoryProperties;
+            m_pDevice->pPhysicalDevice->MemoryProperties;
 
         if( ImGui::CollapsingHeader( Lang::MemoryHeapUsage ) )
         {
@@ -1583,7 +1583,7 @@ namespace Profiler
             ImGuiX::TextAlignRight( "%u", m_Data.m_Stats.m_DrawCount );
 
             ImGui::TextUnformatted( Lang::DrawCallsIndirect );
-            ImGuiX::TextAlignRight( "%u", m_Data.m_Stats.m_DispatchIndirectCount );
+            ImGuiX::TextAlignRight( "%u", m_Data.m_Stats.m_DrawIndirectCount );
 
             ImGui::TextUnformatted( Lang::DispatchCalls );
             ImGuiX::TextAlignRight( "%u", m_Data.m_Stats.m_DispatchCount );

--- a/VkLayer_profiler_layer/profiler_tests/profiler_command_buffer_tests.cpp
+++ b/VkLayer_profiler_layer/profiler_tests/profiler_command_buffer_tests.cpp
@@ -41,8 +41,8 @@ namespace Profiler
         ASSERT_EQ( 1, Prof->m_CommandBuffers.size() );
         const auto it = Prof->m_CommandBuffers.cbegin();
         EXPECT_EQ( commandBuffer, it->first );
-        EXPECT_EQ( commandBuffer, it->second.GetCommandBuffer() );
-        EXPECT_EQ( Vk->CommandPool, it->second.GetCommandPool() );
+        EXPECT_EQ( commandBuffer, it->second.GetHandle() );
+        EXPECT_EQ( Vk->CommandPool, it->second.GetCommandPool().GetHandle() );
     }
 
     TEST_F( ProfilerCommandBufferULT, ProfileSecondaryCommandBuffer )

--- a/VkLayer_profiler_layer/profiler_tests/profiler_command_buffer_tests.cpp
+++ b/VkLayer_profiler_layer/profiler_tests/profiler_command_buffer_tests.cpp
@@ -38,11 +38,11 @@ namespace Profiler
         allocateInfo.commandPool = Vk->CommandPool;
         ASSERT_EQ( VK_SUCCESS, DT.AllocateCommandBuffers( Vk->Device, &allocateInfo, &commandBuffer ) );
 
-        ASSERT_EQ( 1, Prof->m_CommandBuffers.size() );
-        const auto it = Prof->m_CommandBuffers.cbegin();
+        ASSERT_EQ( 1, Prof->m_pCommandBuffers.size() );
+        const auto it = Prof->m_pCommandBuffers.cbegin();
         EXPECT_EQ( commandBuffer, it->first );
-        EXPECT_EQ( commandBuffer, it->second.GetHandle() );
-        EXPECT_EQ( Vk->CommandPool, it->second.GetCommandPool().GetHandle() );
+        EXPECT_EQ( commandBuffer, it->second->GetHandle() );
+        EXPECT_EQ( Vk->CommandPool, it->second->GetCommandPool().GetHandle() );
     }
 
     TEST_F( ProfilerCommandBufferULT, ProfileSecondaryCommandBuffer )

--- a/VkLayer_profiler_layer/profiler_tests/profiler_vulkan_state.h
+++ b/VkLayer_profiler_layer/profiler_tests/profiler_vulkan_state.h
@@ -186,11 +186,13 @@ namespace Profiler
                 id.Instance.ApplicationInfo = ApplicationInfo;
                 init_layer_instance_dispatch_table( Instance, vkGetInstanceProcAddr, id.Instance.Callbacks );
 
+                VkPhysicalDevice_Object& dev = id.Instance.PhysicalDevices[ PhysicalDevice ];
+                dev.Properties = PhysicalDeviceProperties;
+                dev.MemoryProperties = PhysicalDeviceMemoryProperties;
+
                 VkDevice_Functions::Dispatch& dd = VkDevice_Functions::DeviceDispatch.Create( Device );
                 dd.Device.Handle = Device;
-                dd.Device.PhysicalDevice = PhysicalDevice;
-                dd.Device.Properties = PhysicalDeviceProperties;
-                dd.Device.MemoryProperties = PhysicalDeviceMemoryProperties;
+                dd.Device.pPhysicalDevice = &dev;
                 dd.Device.pInstance = &id.Instance;
                 init_layer_device_dispatch_table( Device, vkGetDeviceProcAddr, dd.Device.Callbacks );
 

--- a/VkLayer_profiler_layer/utils/lockable_unordered_map.h
+++ b/VkLayer_profiler_layer/utils/lockable_unordered_map.h
@@ -79,13 +79,26 @@ public:
     void insert( const KeyType& key, const ValueType& value )
     {
         std::scoped_lock lk( m_Mtx );
-        BaseType::insert( { key, value } );
+        BaseType::emplace( key, value );
+    }
+
+    // Insert new value into map (thread-safe)
+    void insert( const KeyType& key, ValueType&& value )
+    {
+        std::scoped_lock lk( m_Mtx );
+        BaseType::emplace( key, std::move( value ) );
     }
 
     // Insert new value into map
     void unsafe_insert( const KeyType& key, const ValueType& value )
     {
-        BaseType::insert( { key, value } );
+        BaseType::emplace( key, value );
+    }
+
+    // Insert new value into map
+    void unsafe_insert( const KeyType& key, ValueType&& value )
+    {
+        BaseType::emplace( key, std::move( value ) );
     }
 
     // Remove value at key (thread-safe)


### PR DESCRIPTION
Query pools can be reset only on graphics or compute queues.

Closes #8 