### PR TITLE
Return device functions via vkGetInstanceProcAddr

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -334,20 +334,6 @@ namespace Profiler
 
     /***********************************************************************************\
 
-    Function:
-        IsAvailable
-
-    Description:
-        Check if profiler has been initialized for this device.
-
-    \***********************************************************************************/
-    bool DeviceProfiler::IsAvailable() const
-    {
-        return m_pDevice != nullptr;
-    }
-
-    /***********************************************************************************\
-
     \***********************************************************************************/
     VkResult DeviceProfiler::SetMode( VkProfilerModeEXT mode )
     {

--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -80,8 +80,6 @@ namespace Profiler
 
         void Destroy();
 
-        bool IsAvailable() const;
-
         // Public interface
         VkResult SetMode( VkProfilerModeEXT );
         VkResult SetSyncMode( VkProfilerSyncModeEXT );

--- a/VkLayer_profiler_layer/profiler_ext/VkProfilerEXT.h
+++ b/VkLayer_profiler_layer/profiler_ext/VkProfilerEXT.h
@@ -28,7 +28,6 @@
 
 enum VkProfilerResultEXT
 {
-    VK_ERROR_NOT_AVAILABLE_EXT = -1000999001
 };
 
 enum VkProfilerStructureTypeEXT
@@ -42,8 +41,7 @@ enum VkProfilerStructureTypeEXT
 
 enum VkProfilerCreateFlagBitsEXT
 {
-    VK_PROFILER_CREATE_DISABLED_BIT_EXT = 1,
-    VK_PROFILER_CREATE_NO_OVERLAY_BIT_EXT = 2,
+    VK_PROFILER_CREATE_NO_OVERLAY_BIT_EXT = 1,
     VK_PROFILER_CREATE_FLAG_BITS_MAX_ENUM_EXT = 0x7FFFFFFF
 };
 

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.cpp
@@ -41,111 +41,106 @@ namespace Profiler
         VkDevice device,
         const char* pName )
     {
+        // VkDevice core functions
+        GETPROCADDR( GetDeviceProcAddr );
+        GETPROCADDR( DestroyDevice );
+        GETPROCADDR( CreateShaderModule );
+        GETPROCADDR( DestroyShaderModule );
+        GETPROCADDR( CreateGraphicsPipelines );
+        GETPROCADDR( CreateComputePipelines );
+        GETPROCADDR( DestroyPipeline );
+        GETPROCADDR( CreateRenderPass );
+        GETPROCADDR( CreateRenderPass2 );
+        GETPROCADDR( DestroyRenderPass );
+        GETPROCADDR( CreateCommandPool );
+        GETPROCADDR( DestroyCommandPool );
+        GETPROCADDR( AllocateCommandBuffers );
+        GETPROCADDR( FreeCommandBuffers );
+        GETPROCADDR( AllocateMemory );
+        GETPROCADDR( FreeMemory );
+
+        // VkCommandBuffer core functions
+        GETPROCADDR( BeginCommandBuffer );
+        GETPROCADDR( EndCommandBuffer );
+        GETPROCADDR( ResetCommandBuffer );
+        GETPROCADDR( CmdBeginRenderPass );
+        GETPROCADDR( CmdEndRenderPass );
+        GETPROCADDR( CmdNextSubpass );
+        GETPROCADDR( CmdBeginRenderPass2 );
+        GETPROCADDR( CmdEndRenderPass2 );
+        GETPROCADDR( CmdNextSubpass2 );
+        GETPROCADDR( CmdBindPipeline );
+        GETPROCADDR( CmdExecuteCommands );
+        GETPROCADDR( CmdPipelineBarrier );
+        GETPROCADDR( CmdDraw );
+        GETPROCADDR( CmdDrawIndirect );
+        GETPROCADDR( CmdDrawIndexed );
+        GETPROCADDR( CmdDrawIndexedIndirect );
+        GETPROCADDR( CmdDrawIndirectCount );
+        GETPROCADDR( CmdDrawIndexedIndirectCount );
+        GETPROCADDR( CmdDispatch );
+        GETPROCADDR( CmdDispatchIndirect );
+        GETPROCADDR( CmdCopyBuffer );
+        GETPROCADDR( CmdCopyBufferToImage );
+        GETPROCADDR( CmdCopyImage );
+        GETPROCADDR( CmdCopyImageToBuffer );
+        GETPROCADDR( CmdClearAttachments );
+        GETPROCADDR( CmdClearColorImage );
+        GETPROCADDR( CmdClearDepthStencilImage );
+        GETPROCADDR( CmdResolveImage );
+        GETPROCADDR( CmdBlitImage );
+        GETPROCADDR( CmdFillBuffer );
+        GETPROCADDR( CmdUpdateBuffer );
+
+        // VkQueue core functions
+        GETPROCADDR( QueueSubmit );
+
+        // VK_KHR_create_renderpass2 functions
+        GETPROCADDR( CreateRenderPass2KHR );
+        GETPROCADDR( CmdBeginRenderPass2KHR );
+        GETPROCADDR( CmdEndRenderPass2KHR );
+        GETPROCADDR( CmdNextSubpass2KHR );
+
+        // VK_EXT_debug_marker functions
+        GETPROCADDR( DebugMarkerSetObjectNameEXT );
+        GETPROCADDR( DebugMarkerSetObjectTagEXT );
+        GETPROCADDR( CmdDebugMarkerInsertEXT );
+        GETPROCADDR( CmdDebugMarkerBeginEXT );
+        GETPROCADDR( CmdDebugMarkerEndEXT );
+
+        // VK_EXT_debug_utils functions
+        GETPROCADDR( SetDebugUtilsObjectNameEXT );
+        GETPROCADDR( SetDebugUtilsObjectTagEXT );
+        GETPROCADDR( CmdInsertDebugUtilsLabelEXT );
+        GETPROCADDR( CmdBeginDebugUtilsLabelEXT );
+        GETPROCADDR( CmdEndDebugUtilsLabelEXT );
+
+        // VK_AMD_draw_indirect_count functions
+        GETPROCADDR( CmdDrawIndirectCountAMD );
+        GETPROCADDR( CmdDrawIndexedIndirectCountAMD );
+
+        // VK_KHR_draw_indirect_count functions
+        GETPROCADDR( CmdDrawIndirectCountKHR );
+        GETPROCADDR( CmdDrawIndexedIndirectCountKHR );
+
+        // VK_KHR_swapchain functions
+        GETPROCADDR( QueuePresentKHR );
+        GETPROCADDR( CreateSwapchainKHR );
+        GETPROCADDR( DestroySwapchainKHR );
+
+        // VK_EXT_profiler functions
+        GETPROCADDR_EXT( vkSetProfilerModeEXT );
+        GETPROCADDR_EXT( vkSetProfilerSyncModeEXT );
+        GETPROCADDR_EXT( vkGetProfilerFrameDataEXT );
+        GETPROCADDR_EXT( vkFreeProfilerFrameDataEXT );
+        GETPROCADDR_EXT( vkFlushProfilerEXT );
+
         if( device )
         {
             auto& dd = DeviceDispatch.Get( device );
 
-            // Check if profiler has been enabled for this device
-            // TODO: What about device functions returned by vkGetInstanceProcAddr
-            if( dd.Profiler.IsAvailable() )
-            {
-                // VkDevice core functions
-                GETPROCADDR( GetDeviceProcAddr );
-                GETPROCADDR( DestroyDevice );
-                GETPROCADDR( CreateShaderModule );
-                GETPROCADDR( DestroyShaderModule );
-                GETPROCADDR( CreateGraphicsPipelines );
-                GETPROCADDR( CreateComputePipelines );
-                GETPROCADDR( DestroyPipeline );
-                GETPROCADDR( CreateRenderPass );
-                GETPROCADDR( CreateRenderPass2 );
-                GETPROCADDR( DestroyRenderPass );
-                GETPROCADDR( CreateCommandPool );
-                GETPROCADDR( DestroyCommandPool );
-                GETPROCADDR( AllocateCommandBuffers );
-                GETPROCADDR( FreeCommandBuffers );
-                GETPROCADDR( AllocateMemory );
-                GETPROCADDR( FreeMemory );
-
-                // VkCommandBuffer core functions
-                GETPROCADDR( BeginCommandBuffer );
-                GETPROCADDR( EndCommandBuffer );
-                GETPROCADDR( ResetCommandBuffer );
-                GETPROCADDR( CmdBeginRenderPass );
-                GETPROCADDR( CmdEndRenderPass );
-                GETPROCADDR( CmdNextSubpass );
-                GETPROCADDR( CmdBeginRenderPass2 );
-                GETPROCADDR( CmdEndRenderPass2 );
-                GETPROCADDR( CmdNextSubpass2 );
-                GETPROCADDR( CmdBindPipeline );
-                GETPROCADDR( CmdExecuteCommands );
-                GETPROCADDR( CmdPipelineBarrier );
-                GETPROCADDR( CmdDraw );
-                GETPROCADDR( CmdDrawIndirect );
-                GETPROCADDR( CmdDrawIndexed );
-                GETPROCADDR( CmdDrawIndexedIndirect );
-                GETPROCADDR( CmdDrawIndirectCount );
-                GETPROCADDR( CmdDrawIndexedIndirectCount );
-                GETPROCADDR( CmdDispatch );
-                GETPROCADDR( CmdDispatchIndirect );
-                GETPROCADDR( CmdCopyBuffer );
-                GETPROCADDR( CmdCopyBufferToImage );
-                GETPROCADDR( CmdCopyImage );
-                GETPROCADDR( CmdCopyImageToBuffer );
-                GETPROCADDR( CmdClearAttachments );
-                GETPROCADDR( CmdClearColorImage );
-                GETPROCADDR( CmdClearDepthStencilImage );
-                GETPROCADDR( CmdResolveImage );
-                GETPROCADDR( CmdBlitImage );
-                GETPROCADDR( CmdFillBuffer );
-                GETPROCADDR( CmdUpdateBuffer );
-
-                // VkQueue core functions
-                GETPROCADDR( QueueSubmit );
-
-                // VK_KHR_create_renderpass2 functions
-                GETPROCADDR( CreateRenderPass2KHR );
-                GETPROCADDR( CmdBeginRenderPass2KHR );
-                GETPROCADDR( CmdEndRenderPass2KHR );
-                GETPROCADDR( CmdNextSubpass2KHR );
-
-                // VK_EXT_debug_marker functions
-                GETPROCADDR( DebugMarkerSetObjectNameEXT );
-                GETPROCADDR( DebugMarkerSetObjectTagEXT );
-                GETPROCADDR( CmdDebugMarkerInsertEXT );
-                GETPROCADDR( CmdDebugMarkerBeginEXT );
-                GETPROCADDR( CmdDebugMarkerEndEXT );
-
-                // VK_EXT_debug_utils functions
-                GETPROCADDR( SetDebugUtilsObjectNameEXT );
-                GETPROCADDR( SetDebugUtilsObjectTagEXT );
-                GETPROCADDR( CmdInsertDebugUtilsLabelEXT );
-                GETPROCADDR( CmdBeginDebugUtilsLabelEXT );
-                GETPROCADDR( CmdEndDebugUtilsLabelEXT );
-
-                // VK_AMD_draw_indirect_count functions
-                GETPROCADDR( CmdDrawIndirectCountAMD );
-                GETPROCADDR( CmdDrawIndexedIndirectCountAMD );
-
-                // VK_KHR_draw_indirect_count functions
-                GETPROCADDR( CmdDrawIndirectCountKHR );
-                GETPROCADDR( CmdDrawIndexedIndirectCountKHR );
-
-                // VK_KHR_swapchain functions
-                GETPROCADDR( QueuePresentKHR );
-                GETPROCADDR( CreateSwapchainKHR );
-                GETPROCADDR( DestroySwapchainKHR );
-
-                // VK_EXT_profiler functions
-                GETPROCADDR_EXT( vkSetProfilerModeEXT );
-                GETPROCADDR_EXT( vkSetProfilerSyncModeEXT );
-                GETPROCADDR_EXT( vkGetProfilerFrameDataEXT );
-                GETPROCADDR_EXT( vkFreeProfilerFrameDataEXT );
-                GETPROCADDR_EXT( vkFlushProfilerEXT );
-            }
-
             // Get function address from the next layer
-            return DeviceDispatch.Get( device ).Device.Callbacks.GetDeviceProcAddr( device, pName );
+            return dd.Device.Callbacks.GetDeviceProcAddr( device, pName );
         }
 
         // Undefined behaviour according to spec - VkDevice handle cannot be null

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions_base.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions_base.cpp
@@ -91,8 +91,6 @@ namespace Profiler
             }
         }
 
-        VkResult result = VK_SUCCESS;
-
         // Check if profiler create info was provided
         const VkProfilerCreateInfoEXT* pProfilerCreateInfo = nullptr;
 
@@ -105,11 +103,8 @@ namespace Profiler
             }
         }
 
-        if( !(pProfilerCreateInfo) || (pProfilerCreateInfo->flags & VK_PROFILER_CREATE_DISABLED_BIT_EXT) == 0 )
-        {
-            // Initialize the profiler object
-            result = dd.Profiler.Initialize( &dd.Device, pProfilerCreateInfo );
-        }
+        // Initialize the profiler object
+        VkResult result = dd.Profiler.Initialize( &dd.Device, pProfilerCreateInfo );
 
         if( result != VK_SUCCESS )
         {

--- a/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkSwapchainKhr_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkSwapchainKhr_functions.cpp
@@ -42,7 +42,6 @@ namespace Profiler
 
         // TODO: Move to separate layer
         const bool createProfilerOverlay =
-            (dd.Profiler.IsAvailable()) &&
             (dd.Profiler.m_Config.m_Flags & VK_PROFILER_CREATE_NO_OVERLAY_BIT_EXT) == 0;
 
         if( createProfilerOverlay )


### PR DESCRIPTION
Drop support for disabling profiler for specific devices (remove VK_PROFILER_CREATE_DISABLED_BIT_EXT flag).
Closes #7 