### PR TITLE
Add per pipeline, per render pass and per command buffer sampling modes.

### DIFF
--- a/VkLayer_profiler_layer/profiler/CMakeLists.txt
+++ b/VkLayer_profiler_layer/profiler/CMakeLists.txt
@@ -25,11 +25,14 @@ project (profiler)
 set (headers
     "profiler.h"
     "profiler_command_buffer.h"
+    "profiler_command_buffer_query_pool.h"
     "profiler_command_pool.h"
     "profiler_counters.h"
     "profiler_data.h"
     "profiler_data_aggregator.h"
     "profiler_helpers.h"
+    "profiler_memory_manager.h"
+    "profiler_query_pool.h"
     "profiler_resources.h"
     "profiler_shader.h"
     "profiler_stat_comparators.h"
@@ -39,8 +42,11 @@ set (headers
 set (sources
     "profiler.cpp"
     "profiler_command_buffer.cpp"
+    "profiler_command_buffer_query_pool.cpp"
     "profiler_command_pool.cpp"
     "profiler_data_aggregator.cpp"
+    "profiler_memory_manager.cpp"
+    "profiler_query_pool.cpp"
     "profiler_sync.cpp"
     # Windows
     "profiler_helpers_windows.cpp"

--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -619,6 +619,7 @@ namespace Profiler
     {
         DeviceProfilerRenderPass deviceProfilerRenderPass;
         deviceProfilerRenderPass.m_Handle = renderPass;
+        deviceProfilerRenderPass.m_Type = DeviceProfilerRenderPassType::eGraphics;
         
         for( uint32_t subpassIndex = 0; subpassIndex < pCreateInfo->subpassCount; ++subpassIndex )
         {
@@ -655,6 +656,7 @@ namespace Profiler
     {
         DeviceProfilerRenderPass deviceProfilerRenderPass;
         deviceProfilerRenderPass.m_Handle = renderPass;
+        deviceProfilerRenderPass.m_Type = DeviceProfilerRenderPassType::eGraphics;
 
         for( uint32_t subpassIndex = 0; subpassIndex < pCreateInfo->subpassCount; ++subpassIndex )
         {

--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -202,6 +202,23 @@ namespace Profiler
             m_Config.m_Flags = pCreateInfo->flags;
         }
 
+        // Configure the profiler from the environment.
+        if (const char* pSamplingMode = std::getenv("VKPROF_SAMPLING_MODE"))
+        {
+            if (std::strcmp(pSamplingMode, "DRAW") == 0)
+                m_Config.m_Mode = VK_PROFILER_MODE_PER_DRAWCALL_EXT;
+            if (std::strcmp(pSamplingMode, "PIPELINE") == 0)
+                m_Config.m_Mode = VK_PROFILER_MODE_PER_PIPELINE_EXT;
+            if (std::strcmp(pSamplingMode, "RENDERPASS") == 0)
+                m_Config.m_Mode = VK_PROFILER_MODE_PER_RENDER_PASS_EXT;
+            if (std::strcmp(pSamplingMode, "COMMANDBUFFER") == 0)
+                m_Config.m_Mode = VK_PROFILER_MODE_PER_COMMAND_BUFFER_EXT;
+            if (std::strcmp(pSamplingMode, "SUBMIT") == 0)
+                m_Config.m_Mode = VK_PROFILER_MODE_PER_SUBMIT_EXT;
+            if (std::strcmp(pSamplingMode, "FRAME") == 0)
+                m_Config.m_Mode = VK_PROFILER_MODE_PER_FRAME_EXT;
+        }
+
         // Check if preemption is enabled
         // It may break the results
         if( ProfilerPlatformFunctions::IsPreemptionEnabled() )
@@ -515,6 +532,7 @@ namespace Profiler
             profilerPipeline.m_Handle = pPipelines[i];
             profilerPipeline.m_ShaderTuple = CreateShaderTuple( pCreateInfos[i] );
             profilerPipeline.m_BindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+            profilerPipeline.m_Type = DeviceProfilerPipelineType::eGraphics;
 
             SetDefaultObjectName( profilerPipeline );
 
@@ -539,6 +557,7 @@ namespace Profiler
             profilerPipeline.m_Handle = pPipelines[ i ];
             profilerPipeline.m_ShaderTuple = CreateShaderTuple( pCreateInfos[ i ] );
             profilerPipeline.m_BindPoint = VK_PIPELINE_BIND_POINT_COMPUTE;
+            profilerPipeline.m_Type = DeviceProfilerPipelineType::eCompute;
 
             SetDefaultObjectName( profilerPipeline );
 
@@ -1122,6 +1141,7 @@ namespace Profiler
         DeviceProfilerPipeline internalPipeline;
         internalPipeline.m_Handle = (VkPipeline)type;
         internalPipeline.m_ShaderTuple.m_Hash = (uint32_t)type;
+        internalPipeline.m_Type = type;
 
         // Assign name for the internal pipeline
         SetObjectName( internalPipeline.m_Handle, pName );

--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -124,6 +124,7 @@ namespace Profiler
         , m_PresentMutex()
         , m_SubmitMutex()
         , m_Data()
+        , m_MemoryManager()
         , m_DataAggregator()
         , m_CurrentFrame( 0 )
         , m_CpuTimestampCounter()
@@ -251,8 +252,11 @@ namespace Profiler
         // Initialize synchroniation manager
         DESTROYANDRETURNONFAIL( m_Synchronization.Initialize( m_pDevice ) );
 
+        // Initialize memory manager
+        DESTROYANDRETURNONFAIL( m_MemoryManager.Initialize( m_pDevice ) );
+
         // Initialize aggregator
-        m_DataAggregator.Initialize( this );
+        DESTROYANDRETURNONFAIL( m_DataAggregator.Initialize( this ) );
 
         // Initialize internal pipelines
         CreateInternalPipeline( DeviceProfilerPipelineType::eCopyBuffer, "CopyBuffer" );
@@ -346,6 +350,7 @@ namespace Profiler
         m_Allocations.clear();
 
         m_Synchronization.Destroy();
+        m_MemoryManager.Destroy();
 
         if( m_SubmitFence != VK_NULL_HANDLE )
         {

--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -23,6 +23,7 @@
 #include "profiler_command_pool.h"
 #include "profiler_data_aggregator.h"
 #include "profiler_helpers.h"
+#include "profiler_memory_manager.h"
 #include "profiler_data.h"
 #include "profiler_sync.h"
 #include "profiler_layer_objects/VkObject.h"
@@ -133,6 +134,7 @@ namespace Profiler
         mutable std::mutex      m_DataMutex;
         DeviceProfilerFrameData m_Data;
 
+        DeviceProfilerMemoryManager m_MemoryManager;
         ProfilerDataAggregator  m_DataAggregator;
 
         uint32_t                m_CurrentFrame;

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
@@ -114,7 +114,7 @@ namespace Profiler
 
         void SendTimestampQuery( VkPipelineStageFlagBits );
 
-        void SetupCommandBufferForStatCounting( const DeviceProfilerPipeline& );
+        bool SetupCommandBufferForStatCounting( const DeviceProfilerPipeline& );
         void SetupCommandBufferForSecondaryBuffers();
 
         DeviceProfilerPipelineData& GetCurrentPipeline();

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
@@ -117,6 +117,8 @@ namespace Profiler
         bool SetupCommandBufferForStatCounting( const DeviceProfilerPipeline& );
         void SetupCommandBufferForSecondaryBuffers();
 
+        DeviceProfilerRenderPassType GetRenderPassTypeFromPipelineType( DeviceProfilerPipelineType ) const;
+
         DeviceProfilerPipelineData& GetCurrentPipeline();
 
     };

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 #pragma once
+#include "profiler_command_buffer_query_pool.h"
 #include "profiler_data.h"
 #include "profiler_counters.h"
 #include <vulkan/vk_layer.h>
@@ -77,42 +78,36 @@ namespace Profiler
         const DeviceProfilerCommandBufferData& GetData();
 
     protected:
-        DeviceProfiler& m_Profiler;
-        DeviceProfilerCommandPool& m_CommandPool;
+        DeviceProfiler&                     m_Profiler;
+        DeviceProfilerCommandPool&          m_CommandPool;
 
-        const VkCommandBuffer m_CommandBuffer;
-        const VkCommandBufferLevel m_Level;
+        const VkCommandBuffer               m_CommandBuffer;
+        const VkCommandBufferLevel          m_Level;
 
-        bool            m_ProfilingEnabled;
-        bool            m_Dirty;
+        bool                                m_ProfilingEnabled;
+        bool                                m_Dirty;
 
         std::unordered_set<VkCommandBuffer> m_SecondaryCommandBuffers;
 
-        std::vector<VkQueryPool> m_QueryPools;
-        uint32_t        m_QueryPoolSize;
-        uint32_t        m_CurrentQueryPoolIndex;
-        uint32_t        m_CurrentQueryIndex;
+        CommandBufferQueryPool*             m_pQueryPool;
 
-        VkQueryPool     m_PerformanceQueryPoolINTEL;
+        DeviceProfilerDrawcallStats         m_Stats;
+        DeviceProfilerCommandBufferData     m_Data;
 
-        DeviceProfilerDrawcallStats m_Stats;
-        DeviceProfilerCommandBufferData m_Data;
+        DeviceProfilerRenderPass*           m_pCurrentRenderPass;
+        DeviceProfilerRenderPassData*       m_pCurrentRenderPassData;
+        DeviceProfilerSubpassData*          m_pCurrentSubpassData;
+        DeviceProfilerPipelineData*         m_pCurrentPipelineData;
+        DeviceProfilerDrawcall*             m_pCurrentDrawcallData;
 
-        DeviceProfilerRenderPass* m_pCurrentRenderPass;
-        DeviceProfilerRenderPassData* m_pCurrentRenderPassData;
+        uint32_t                            m_CurrentSubpassIndex;
 
-        uint32_t               m_CurrentSubpassIndex;
-
-        DeviceProfilerPipeline m_GraphicsPipeline;
-        DeviceProfilerPipeline m_ComputePipeline;
-
-        void AllocateQueryPool();
+        DeviceProfilerPipeline              m_GraphicsPipeline;
+        DeviceProfilerPipeline              m_ComputePipeline;
 
         void EndSubpass();
 
         void IncrementStat( const DeviceProfilerDrawcall& );
-
-        void SendTimestampQuery( VkPipelineStageFlagBits );
 
         bool SetupCommandBufferForStatCounting( const DeviceProfilerPipeline& );
         void SetupCommandBufferForSecondaryBuffers();

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "profiler_command_buffer_query_pool.h"
+#include "profiler.h"
+
+#include <assert.h>
+
+namespace Profiler
+{
+    CommandBufferQueryPool::CommandBufferQueryPool( DeviceProfiler& profiler, VkCommandBufferLevel level )
+        : m_Profiler( profiler )
+        , m_Device( *profiler.m_pDevice )
+        , m_pQueryPools()
+        , m_QueryPoolSize( 32768 )
+        , m_CurrentQueryPoolIndex( 0 )
+        , m_CurrentQueryIndex( UINT32_MAX )
+        , m_PerformanceQueryPoolINTEL( VK_NULL_HANDLE )
+    {
+        // Initialize performance query once
+        if( (level == VK_COMMAND_BUFFER_LEVEL_PRIMARY) &&
+            (m_Profiler.m_MetricsApiINTEL.IsAvailable()) )
+        {
+            VkQueryPoolCreateInfoINTEL intelCreateInfo = {};
+            intelCreateInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO_INTEL;
+            intelCreateInfo.performanceCountersSampling = VK_QUERY_POOL_SAMPLING_MODE_MANUAL_INTEL;
+
+            VkQueryPoolCreateInfo createInfo = {};
+            createInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+            createInfo.pNext = &intelCreateInfo;
+            createInfo.queryType = VK_QUERY_TYPE_PERFORMANCE_QUERY_INTEL;
+            createInfo.queryCount = 1;
+
+            m_Profiler.m_pDevice->Callbacks.CreateQueryPool(
+                m_Profiler.m_pDevice->Handle,
+                &createInfo,
+                nullptr,
+                &m_PerformanceQueryPoolINTEL );
+        }
+    }
+
+    CommandBufferQueryPool::~CommandBufferQueryPool()
+    {
+        for( auto* pQueryPool : m_pQueryPools )
+        {
+            delete pQueryPool;
+        }
+    }
+}

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.h
@@ -1,0 +1,177 @@
+// Copyright (c) 2022 Lukasz Stalmirski
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include "profiler_data.h"
+#include "profiler_counters.h"
+#include "profiler_query_pool.h"
+#include "profiler_layer_objects/VkDevice_object.h"
+
+#include <vulkan/vk_layer.h>
+
+#include <vector>
+
+namespace Profiler
+{
+    class DeviceProfiler;
+
+    /***********************************************************************************\
+
+    Class:
+        CommandBufferQueryPool
+
+    Description:
+        Wrapper for set of VkQueryPools used by a single command buffer.
+
+    \***********************************************************************************/
+    class CommandBufferQueryPool
+    {
+    public:
+        CommandBufferQueryPool( DeviceProfiler&, VkCommandBufferLevel );
+        ~CommandBufferQueryPool();
+
+        CommandBufferQueryPool( const CommandBufferQueryPool& ) = delete;
+
+        VkQueryPool GetPerformanceQueryPoolHandle() const { return m_PerformanceQueryPoolINTEL; }
+
+        __forceinline void PreallocateQueries( VkCommandBuffer commandBuffer )
+        {
+            if( ( m_pQueryPools.empty() ) ||
+                ( ( m_CurrentQueryPoolIndex == m_pQueryPools.size() ) &&
+                    ( m_CurrentQueryIndex != UINT32_MAX ) &&
+                    ( m_CurrentQueryIndex >= ( m_QueryPoolSize * 0.8f ) ) ) )
+            {
+                AllocateQueryPool( commandBuffer );
+            }
+        }
+
+        __forceinline void Reset( VkCommandBuffer commandBuffer )
+        {
+            // Reset the full query pools.
+            for( uint32_t queryPoolIndex = 0; queryPoolIndex < m_CurrentQueryPoolIndex; ++queryPoolIndex )
+            {
+                m_Device.Callbacks.CmdResetQueryPool(
+                    commandBuffer,
+                    m_pQueryPools[ queryPoolIndex ]->GetQueryPoolHandle(),
+                    0, m_QueryPoolSize );
+            }
+
+            // Reset the last query pool.
+            if( m_CurrentQueryIndex != UINT32_MAX )
+            {
+                m_Device.Callbacks.CmdResetQueryPool(
+                    commandBuffer,
+                    m_pQueryPools[ m_CurrentQueryPoolIndex ]->GetQueryPoolHandle(),
+                    0, (m_CurrentQueryIndex + 1) );
+            }
+
+            m_CurrentQueryIndex = UINT32_MAX;
+            m_CurrentQueryPoolIndex = 0;
+        }
+
+        __forceinline void ResolveTimestampsGpu( VkCommandBuffer commandBuffer )
+        {
+            // Copy data from the full query pools.
+            for( uint32_t queryPoolIndex = 0; queryPoolIndex < m_CurrentQueryPoolIndex; ++queryPoolIndex )
+            {
+                m_pQueryPools[ queryPoolIndex ]->ResolveQueryDataGpu( commandBuffer, m_QueryPoolSize );
+            }
+
+            // Copy data from the last query pool.
+            if( m_CurrentQueryIndex != UINT32_MAX )
+            {
+                m_pQueryPools[ m_CurrentQueryPoolIndex ]->ResolveQueryDataGpu( commandBuffer, m_CurrentQueryIndex + 1 );
+            }
+        }
+
+        __forceinline void ResolveTimestampsCpu()
+        {
+            // Copy data from the full query pools.
+            for( uint32_t queryPoolIndex = 0; queryPoolIndex < m_CurrentQueryPoolIndex; ++queryPoolIndex )
+            {
+                m_pQueryPools[ queryPoolIndex ]->ResolveQueryDataCpu( m_QueryPoolSize );
+            }
+
+            // Copy data from the last query pool.
+            if( m_CurrentQueryIndex != UINT32_MAX )
+            {
+                m_pQueryPools[ m_CurrentQueryPoolIndex ]->ResolveQueryDataCpu( m_CurrentQueryIndex + 1 );
+            }
+        }
+
+        __forceinline uint64_t WriteTimestamp( VkCommandBuffer commandBuffer, VkPipelineStageFlagBits stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT )
+        {
+            // Allocate query from the pool
+            m_CurrentQueryIndex++;
+
+            if( m_CurrentQueryIndex == m_QueryPoolSize )
+            {
+                // Try to reuse next query pool
+                m_CurrentQueryIndex = 0;
+                m_CurrentQueryPoolIndex++;
+
+                if( m_CurrentQueryPoolIndex == m_pQueryPools.size() )
+                {
+                    AllocateQueryPool( commandBuffer );
+                }
+            }
+
+            // Send the query
+            m_Device.Callbacks.CmdWriteTimestamp(
+                commandBuffer,
+                stage,
+                m_pQueryPools[ m_CurrentQueryPoolIndex ]->GetQueryPoolHandle(),
+                m_CurrentQueryIndex );
+
+            // Return index to the allocated query.
+            return ( static_cast<uint64_t>( m_CurrentQueryPoolIndex ) << 32 ) |
+                   ( static_cast<uint64_t>( m_CurrentQueryIndex ) & 0xFFFFFFFF );
+        }
+
+        __forceinline uint64_t GetTimestampData( uint64_t query ) const
+        {
+            const uint32_t queryPoolIndex = static_cast<uint32_t>( query >> 32 );
+            const uint32_t queryIndex = static_cast<uint32_t>( query & 0xFFFFFFFF );
+
+            return m_pQueryPools[ queryPoolIndex ]->GetQueryData( queryIndex );
+        }
+
+    protected:
+        DeviceProfiler&                  m_Profiler;
+        VkDevice_Object&                 m_Device;
+
+        std::vector<TimestampQueryPool*> m_pQueryPools;
+        uint32_t                         m_QueryPoolSize;
+        uint32_t                         m_CurrentQueryPoolIndex;
+        uint32_t                         m_CurrentQueryIndex;
+
+        VkQueryPool                      m_PerformanceQueryPoolINTEL;
+
+        __forceinline void AllocateQueryPool( VkCommandBuffer commandBuffer )
+        {
+            auto* pQueryPool = m_pQueryPools.emplace_back(
+                new TimestampQueryPool( m_Profiler, m_QueryPoolSize ) );
+
+            // Pools must be reset before first use
+            m_Device.Callbacks.CmdResetQueryPool(
+                commandBuffer, pQueryPool->GetQueryPoolHandle(), 0, m_QueryPoolSize );
+        }
+    };
+}

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <vector>
 #include <list>
+#include <deque>
 #include <unordered_map>
 #include <cstring>
 #include <vulkan/vulkan.h>
@@ -32,7 +33,7 @@
 
 namespace Profiler
 {
-    template<typename T> using ContainerType = std::list<T>;
+    template<typename T> using ContainerType = std::deque<T>;
 
     /***********************************************************************************\
 
@@ -110,6 +111,7 @@ namespace Profiler
     \***********************************************************************************/
     enum class DeviceProfilerRenderPassType : uint32_t
     {
+        eNone,
         eGraphics,
         eCompute,
         eCopy
@@ -294,8 +296,8 @@ namespace Profiler
     {
         DeviceProfilerDrawcallType                          m_Type = {};
         DeviceProfilerDrawcallPayload                       m_Payload = {};
-        uint64_t                                            m_BeginTimestamp = {};
-        uint64_t                                            m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = UINT64_MAX;
+        uint64_t                                            m_EndTimestamp = UINT64_MAX;
 
         inline DeviceProfilerPipelineType GetPipelineType() const
         {
@@ -316,7 +318,7 @@ namespace Profiler
             if( dc.GetPipelineType() == DeviceProfilerPipelineType::eDebug )
             {
                 // Create copy of already stored string
-                m_Payload.m_DebugLabel.m_pName = strdup( dc.m_Payload.m_DebugLabel.m_pName );
+                m_Payload.m_DebugLabel.m_pName = _strdup( dc.m_Payload.m_DebugLabel.m_pName );
             }
         }
 
@@ -441,8 +443,8 @@ namespace Profiler
         VkPipelineBindPoint                                 m_BindPoint = {};
         ProfilerShaderTuple                                 m_ShaderTuple = {};
         DeviceProfilerPipelineType                          m_Type = {};
-        uint64_t                                            m_BeginTimestamp = {};
-        uint64_t                                            m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = UINT64_MAX;
+        uint64_t                                            m_EndTimestamp = UINT64_MAX;
         ContainerType<struct DeviceProfilerDrawcall>        m_Drawcalls = {};
 
         inline DeviceProfilerPipelineData() = default;
@@ -489,11 +491,11 @@ namespace Profiler
     {
         uint32_t                                            m_Index = {};
         VkSubpassContents                                   m_Contents = {};
-        uint64_t                                            m_BeginTimestamp = {};
-        uint64_t                                            m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = UINT64_MAX;
+        uint64_t                                            m_EndTimestamp = UINT64_MAX;
 
         ContainerType<struct DeviceProfilerPipelineData>    m_Pipelines = {};
-        ContainerType<struct DeviceProfilerCommandBufferData> m_SecondaryCommandBuffers = {};
+        std::list<struct DeviceProfilerCommandBufferData>   m_SecondaryCommandBuffers = {};
     };
 
     /***********************************************************************************\
@@ -528,8 +530,8 @@ namespace Profiler
         VkAttachmentLoadOp                                  m_ColorAttachmentLoadOp = {};
         VkAttachmentLoadOp                                  m_DepthAttachmentLoadOp = {};
         VkAttachmentLoadOp                                  m_StencilAttachmentLoadOp = {};
-        uint64_t                                            m_BeginTimestamp = {};
-        uint64_t                                            m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = UINT64_MAX;
+        uint64_t                                            m_EndTimestamp = UINT64_MAX;
     };
 
     /***********************************************************************************\
@@ -546,8 +548,8 @@ namespace Profiler
         VkAttachmentStoreOp                                 m_ColorAttachmentStoreOp = {};
         VkAttachmentStoreOp                                 m_DepthAttachmentStoreOp = {};
         VkAttachmentStoreOp                                 m_StencilAttachmentStoreOp = {};
-        uint64_t                                            m_BeginTimestamp = {};
-        uint64_t                                            m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = UINT64_MAX;
+        uint64_t                                            m_EndTimestamp = UINT64_MAX;
     };
 
     /***********************************************************************************\
@@ -562,8 +564,8 @@ namespace Profiler
     struct DeviceProfilerRenderPassData
     {
         VkRenderPass                                        m_Handle = {};
-        uint64_t                                            m_BeginTimestamp = {};
-        uint64_t                                            m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = UINT64_MAX;
+        uint64_t                                            m_EndTimestamp = UINT64_MAX;
 
         DeviceProfilerRenderPassType                        m_Type = {};
 
@@ -587,8 +589,8 @@ namespace Profiler
         VkCommandBuffer                                     m_Handle = {};
         VkCommandBufferLevel                                m_Level = {};
         DeviceProfilerDrawcallStats                         m_Stats = {};
-        uint64_t                                            m_BeginTimestamp = {};
-        uint64_t                                            m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = UINT64_MAX;
+        uint64_t                                            m_EndTimestamp = UINT64_MAX;
 
         ContainerType<struct DeviceProfilerRenderPassData>  m_RenderPasses = {};
 
@@ -612,8 +614,8 @@ namespace Profiler
         std::vector<VkSemaphore>                            m_SignalSemaphores = {};
         std::vector<VkSemaphore>                            m_WaitSemaphores = {};
 
-        uint64_t                                            m_BeginTimestamp = {};
-        uint64_t                                            m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = UINT64_MAX;
+        uint64_t                                            m_EndTimestamp = UINT64_MAX;
     };
 
     /***********************************************************************************\
@@ -710,8 +712,6 @@ namespace Profiler
         DeviceProfilerDrawcallStats                         m_Stats = {};
 
         uint64_t                                            m_Ticks = {};
-
-        VkProfilerModeEXT                                   m_SamplingMode = {};
 
         DeviceProfilerMemoryData                            m_Memory = {};
         DeviceProfilerCPUData                               m_CPU = {};

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -408,6 +408,7 @@ namespace Profiler
         VkPipeline                                          m_Handle = {};
         VkPipelineBindPoint                                 m_BindPoint = {};
         ProfilerShaderTuple                                 m_ShaderTuple = {};
+        DeviceProfilerPipelineType                          m_Type = {};
     };
 
     /***********************************************************************************\
@@ -424,6 +425,7 @@ namespace Profiler
         VkPipeline                                          m_Handle = {};
         VkPipelineBindPoint                                 m_BindPoint = {};
         ProfilerShaderTuple                                 m_ShaderTuple = {};
+        DeviceProfilerPipelineType                          m_Type = {};
         uint64_t                                            m_BeginTimestamp = {};
         uint64_t                                            m_EndTimestamp = {};
         ContainerType<struct DeviceProfilerDrawcall>        m_Drawcalls = {};
@@ -434,6 +436,7 @@ namespace Profiler
             : m_Handle( pipeline.m_Handle )
             , m_BindPoint( pipeline.m_BindPoint )
             , m_ShaderTuple( pipeline.m_ShaderTuple )
+            , m_Type( pipeline.m_Type )
         {
         }
 

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -102,6 +102,21 @@ namespace Profiler
 
     /***********************************************************************************\
 
+    Enumeration:
+        DeviceProfilerRenderPassType
+
+    Description:
+
+    \***********************************************************************************/
+    enum class DeviceProfilerRenderPassType : uint32_t
+    {
+        eGraphics,
+        eCompute,
+        eCopy
+    };
+
+    /***********************************************************************************\
+
     Drawcall-specific playloads
 
     \***********************************************************************************/
@@ -493,6 +508,7 @@ namespace Profiler
     struct DeviceProfilerRenderPass
     {
         VkRenderPass                                        m_Handle = {};
+        DeviceProfilerRenderPassType                        m_Type = {};
         std::vector<struct DeviceProfilerSubpass>           m_Subpasses = {};
         uint32_t                                            m_ClearColorAttachmentCount = {};
         uint32_t                                            m_ClearDepthStencilAttachmentCount = {};
@@ -548,6 +564,8 @@ namespace Profiler
         VkRenderPass                                        m_Handle = {};
         uint64_t                                            m_BeginTimestamp = {};
         uint64_t                                            m_EndTimestamp = {};
+
+        DeviceProfilerRenderPassType                        m_Type = {};
 
         DeviceProfilerRenderPassBeginData                   m_Begin = {};
         DeviceProfilerRenderPassEndData                     m_End = {};
@@ -692,6 +710,8 @@ namespace Profiler
         DeviceProfilerDrawcallStats                         m_Stats = {};
 
         uint64_t                                            m_Ticks = {};
+
+        VkProfilerModeEXT                                   m_SamplingMode = {};
 
         DeviceProfilerMemoryData                            m_Memory = {};
         DeviceProfilerCPUData                               m_CPU = {};

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
@@ -253,6 +253,7 @@ namespace Profiler
         auto aggregatedVendorMetrics = AggregateVendorMetrics();
 
         DeviceProfilerFrameData frameData;
+        frameData.m_SamplingMode = m_pProfiler->m_Config.m_Mode;
         frameData.m_Submits = { aggregatedSubmits.begin(), aggregatedSubmits.end() };
         frameData.m_TopPipelines = { aggregatedPipelines.begin(), aggregatedPipelines.end() };
         frameData.m_VendorMetrics = aggregatedVendorMetrics;

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
@@ -68,13 +68,13 @@ namespace Profiler
         void Aggregate();
         void Reset();
 
-        DeviceProfilerFrameData GetAggregatedData() const;
+        DeviceProfilerFrameData GetAggregatedData();
 
     private:
         DeviceProfiler* m_pProfiler;
 
-        std::list<DeviceProfilerSubmitBatch> m_Submits;
-        std::list<DeviceProfilerSubmitBatchData> m_AggregatedData;
+        ContainerType<DeviceProfilerSubmitBatch> m_Submits;
+        ContainerType<DeviceProfilerSubmitBatchData> m_AggregatedData;
 
         std::unordered_map<ProfilerCommandBuffer*, DeviceProfilerCommandBufferData> m_Data;
 
@@ -85,7 +85,7 @@ namespace Profiler
 
         std::vector<VkProfilerPerformanceCounterResultEXT> AggregateVendorMetrics() const;
 
-        std::list<DeviceProfilerPipelineData> CollectTopPipelines() const;
+        ContainerType<DeviceProfilerPipelineData> CollectTopPipelines() const;
 
         void CollectPipelinesFromCommandBuffer(
             const DeviceProfilerCommandBufferData&,

--- a/VkLayer_profiler_layer/profiler/profiler_memory_manager.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_memory_manager.cpp
@@ -1,0 +1,279 @@
+// Copyright (c) 2022 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "profiler_memory_manager.h"
+#include "profiler_layer_objects/VkDevice_object.h"
+
+#include <assert.h>
+
+namespace Profiler
+{
+    DeviceProfilerMemoryManager::DeviceProfilerMemoryManager()
+        : m_pDevice( nullptr )
+        , m_MemoryAllocationMutex()
+        , m_DefaultMemoryPoolSize( 16 * 1024 * 1024 )
+        , m_DefaultMemoryBlockSize( 4 * 1024 )
+        , m_DeviceMemoryProperties()
+        , m_MemoryPools()
+    {
+    }
+
+    VkResult DeviceProfilerMemoryManager::Initialize( VkDevice_Object* pDevice )
+    {
+        assert( !m_pDevice );
+        m_pDevice = pDevice;
+
+        // Get device memory properties.
+        m_DeviceMemoryProperties = m_pDevice->pPhysicalDevice->MemoryProperties;
+
+        return VK_SUCCESS;
+    }
+
+    void DeviceProfilerMemoryManager::Destroy()
+    {
+        // Free all device memory allocations.
+        for( auto& memoryPool : m_MemoryPools )
+        {
+            m_pDevice->Callbacks.FreeMemory(
+                m_pDevice->Handle,
+                memoryPool.m_DeviceMemory,
+                nullptr );
+        }
+
+        m_MemoryPools.clear();
+
+        // Invalidate pointer to the device object.
+        m_pDevice = nullptr;
+    }
+
+    VkResult DeviceProfilerMemoryManager::AllocateMemory(
+        const VkMemoryRequirements& memoryRequirements,
+        VkMemoryPropertyFlags requiredFlags,
+        DeviceProfilerMemoryAllocation* pAllocation )
+    {
+        std::scoped_lock lk( m_MemoryAllocationMutex );
+
+        VkResult result = VK_ERROR_FRAGMENTED_POOL;
+
+        // Compute number of blocks that have to be allocated.
+        const size_t requiredBlockCount = (memoryRequirements.size + m_DefaultMemoryBlockSize - 1) / m_DefaultMemoryBlockSize; 
+
+        // Try to suballocate from an existing pool.
+        for( auto& memoryPool : m_MemoryPools )
+        {
+            if( (memoryPool.m_FreeSize >= memoryRequirements.size) &&
+                ((memoryPool.m_Flags & requiredFlags) == requiredFlags) &&
+                ((memoryRequirements.memoryTypeBits & (1U << memoryPool.m_MemoryTypeIndex)) != 0) )
+            {
+                size_t firstFreeBlockIndex = 0;
+                size_t freeBlockCount = 0;
+
+                const size_t memoryPoolBlockCount = memoryPool.m_Allocations.size();
+                for( size_t i = 0; i < memoryPoolBlockCount; ++i )
+                {
+                    // Skip allocated blocks.
+                    while( (i < memoryPoolBlockCount) &&
+                           (memoryPool.m_Allocations[i]) )
+                        ++i;
+
+                    // Find first free block with the required alignment.
+                    while( (i < memoryPoolBlockCount) &&
+                            !(memoryPool.m_Allocations[i]) &&
+                            (((i * m_DefaultMemoryBlockSize) & (memoryRequirements.alignment - 1)) != 0) )
+                        ++i;
+
+                    firstFreeBlockIndex = i;
+                    freeBlockCount = 0;
+
+                    // Count free blocks.
+                    while( (i < memoryPoolBlockCount) &&
+                           (freeBlockCount < requiredBlockCount) &&
+                           !(memoryPool.m_Allocations[i]) )
+                        ++i, ++freeBlockCount;
+
+                    if( freeBlockCount == requiredBlockCount )
+                        break;
+                }
+
+                // Check if memory can be suballocated.
+                if( freeBlockCount == requiredBlockCount )
+                {
+                    // Mark blocks as allocated.
+                    const size_t lastBlockIndex = firstFreeBlockIndex + freeBlockCount;
+                    for( size_t i = firstFreeBlockIndex; i < lastBlockIndex; ++i )
+                    {
+                        memoryPool.m_Allocations[ i ] = true;
+                    }
+
+                    // Create allocation struct.
+                    pAllocation->m_pPool = &memoryPool;
+                    pAllocation->m_Offset = firstFreeBlockIndex * m_DefaultMemoryBlockSize;
+                    pAllocation->m_Size = freeBlockCount * m_DefaultMemoryBlockSize;
+                    pAllocation->m_pMappedMemory = nullptr;
+
+                    if( memoryPool.m_pMappedMemory != nullptr )
+                    {
+                        pAllocation->m_pMappedMemory =
+                            reinterpret_cast<std::byte*>( memoryPool.m_pMappedMemory ) + pAllocation->m_Offset;
+                    }
+
+                    result = VK_SUCCESS;
+                }
+            }
+        }
+
+        if( result != VK_SUCCESS )
+        {
+            // Create new memory pool.
+            DeviceProfilerMemoryPool* pMemoryPool = nullptr;
+            result = AllocatePool(
+                std::max( memoryRequirements.size, m_DefaultMemoryPoolSize ),
+                memoryRequirements.memoryTypeBits,
+                requiredFlags,
+                &pMemoryPool );
+
+            if( result == VK_SUCCESS )
+            {
+                // Mark blocks as allocated.
+                for( size_t i = 0; i < requiredBlockCount; ++i )
+                {
+                    pMemoryPool->m_Allocations[ i ] = true;
+                }
+
+                // Create allocation struct.
+                pAllocation->m_pPool = pMemoryPool;
+                pAllocation->m_Offset = 0;
+                pAllocation->m_Size = requiredBlockCount * m_DefaultMemoryBlockSize;
+
+                if( pAllocation->m_pPool->m_pMappedMemory != nullptr )
+                {
+                    pAllocation->m_pMappedMemory =
+                        reinterpret_cast<std::byte*>( pMemoryPool->m_pMappedMemory ) + pAllocation->m_Offset;
+                }
+            }
+        }
+
+        if( result == VK_SUCCESS )
+        {
+            pAllocation->m_pPool->m_FreeSize -= pAllocation->m_Size;
+        }
+
+        return result;
+    }
+
+    void DeviceProfilerMemoryManager::FreeMemory(
+        DeviceProfilerMemoryAllocation* pAllocation )
+    {
+        std::scoped_lock lk( m_MemoryAllocationMutex );
+
+        auto* pMemoryPool = pAllocation->m_pPool;
+
+        const size_t firstBlockIndex = pAllocation->m_Offset / m_DefaultMemoryBlockSize;
+        const size_t blockCount = pAllocation->m_Size / m_DefaultMemoryBlockSize;
+
+        // Mark blocks as free.
+        const size_t lastBlockIndex = firstBlockIndex + blockCount;
+        for( size_t i = firstBlockIndex; i < lastBlockIndex; ++i )
+        {
+            pMemoryPool->m_Allocations[ i ] = false;
+        }
+
+        pMemoryPool->m_FreeSize += pAllocation->m_Size;
+    }
+
+    VkResult DeviceProfilerMemoryManager::AllocatePool(
+        VkDeviceSize size,
+        uint32_t requiredTypeBits,
+        VkMemoryPropertyFlags requiredFlags,
+        DeviceProfilerMemoryPool** ppPool )
+    {
+        VkResult result = VK_SUCCESS;
+        try
+        {
+            const size_t blockCount = ((size + m_DefaultMemoryBlockSize - 1) / m_DefaultMemoryBlockSize);
+
+            auto* pMemoryPool = &m_MemoryPools.emplace_back();
+            pMemoryPool->m_Allocations.resize( blockCount );
+            pMemoryPool->m_Size = blockCount * m_DefaultMemoryBlockSize;
+            pMemoryPool->m_FreeSize = pMemoryPool->m_Size;
+
+            // Find suitable memory type index.
+            pMemoryPool->m_MemoryTypeIndex = UINT32_MAX;
+            for( uint32_t i = 0; i < m_DeviceMemoryProperties.memoryTypeCount; ++i )
+            {
+                const auto& memoryProperties = m_DeviceMemoryProperties.memoryTypes[ i ];
+                if( ((requiredTypeBits & (1U << i)) != 0) &&
+                    ((memoryProperties.propertyFlags & requiredFlags) == requiredFlags) )
+                {
+                    pMemoryPool->m_MemoryTypeIndex = i;
+                    pMemoryPool->m_Flags = memoryProperties.propertyFlags;
+                    break;
+                }
+            }
+
+            if( pMemoryPool->m_MemoryTypeIndex == UINT32_MAX )
+            {
+                // Required memory type not found.
+                result = VK_ERROR_OUT_OF_DEVICE_MEMORY;
+            }
+
+            if( result == VK_SUCCESS )
+            {
+                // Allocate device memory.
+                VkMemoryAllocateInfo memoryAllocateInfo = {};
+                memoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+                memoryAllocateInfo.allocationSize = pMemoryPool->m_Size;
+                memoryAllocateInfo.memoryTypeIndex = pMemoryPool->m_MemoryTypeIndex;
+
+                result = m_pDevice->Callbacks.AllocateMemory(
+                    m_pDevice->Handle,
+                    &memoryAllocateInfo,
+                    nullptr,
+                    &pMemoryPool->m_DeviceMemory );
+            }
+
+            if( (result == VK_SUCCESS) &&
+                ((pMemoryPool->m_Flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0) )
+            {
+                // Map host-visible memory.
+                result = m_pDevice->Callbacks.MapMemory(
+                    m_pDevice->Handle,
+                    pMemoryPool->m_DeviceMemory, 0,
+                    pMemoryPool->m_Size, 0,
+                    &pMemoryPool->m_pMappedMemory );
+            }
+
+            if( result == VK_SUCCESS )
+            {
+                *ppPool = pMemoryPool;
+            }
+        }
+        catch( std::bad_alloc& )
+        {
+            result = VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+        catch( ... )
+        {
+            result = VK_ERROR_UNKNOWN;
+        }
+
+        return result;
+    }
+}

--- a/VkLayer_profiler_layer/profiler/profiler_memory_manager.h
+++ b/VkLayer_profiler_layer/profiler/profiler_memory_manager.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2022 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <vulkan/vk_layer.h>
+#include <list>
+#include <vector>
+#include <mutex>
+
+namespace Profiler
+{
+    struct VkDevice_Object;
+
+    struct DeviceProfilerMemoryPool
+    {
+        VkDeviceMemory m_DeviceMemory;
+        VkDeviceSize m_Size;
+        VkDeviceSize m_FreeSize;
+        uint32_t m_MemoryTypeIndex;
+        VkMemoryPropertyFlags m_Flags;
+        void* m_pMappedMemory;
+        std::vector<bool> m_Allocations;
+    };
+
+    struct DeviceProfilerMemoryAllocation
+    {
+        DeviceProfilerMemoryPool* m_pPool;
+        VkDeviceSize m_Offset;
+        VkDeviceSize m_Size;
+        void* m_pMappedMemory;
+    };
+
+    class DeviceProfilerMemoryManager
+    {
+    public:
+        DeviceProfilerMemoryManager();
+
+        VkResult Initialize( VkDevice_Object* pDevice );
+        void Destroy();
+
+        VkResult AllocateMemory(
+            const VkMemoryRequirements& memoryRequirements,
+            VkMemoryPropertyFlags requiredFlags,
+            DeviceProfilerMemoryAllocation* pAllocation );
+
+        void FreeMemory(
+            DeviceProfilerMemoryAllocation* pAllocation );
+
+    private:
+        VkDevice_Object* m_pDevice;
+
+        std::mutex m_MemoryAllocationMutex;
+
+        VkDeviceSize m_DefaultMemoryPoolSize;
+        VkDeviceSize m_DefaultMemoryBlockSize;
+
+        VkPhysicalDeviceMemoryProperties m_DeviceMemoryProperties;
+
+        std::list<DeviceProfilerMemoryPool> m_MemoryPools;
+
+        VkResult AllocatePool(
+            VkDeviceSize size,
+            uint32_t requiredTypeBits,
+            VkMemoryPropertyFlags requiredFlags,
+            DeviceProfilerMemoryPool** ppPool );
+    };
+}

--- a/VkLayer_profiler_layer/profiler/profiler_query_pool.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_query_pool.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) 2022 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "profiler_query_pool.h"
+#include "profiler_memory_manager.h"
+#include "profiler.h"
+
+#define VKPROF_USE_GPU_TIMESTAMP_BUFFER 0
+
+namespace Profiler
+{
+    TimestampQueryPool::TimestampQueryPool( DeviceProfiler& profiler, uint32_t queryCount )
+        : m_Profiler( profiler )
+        , m_QueryPool( VK_NULL_HANDLE )
+        , m_QueryResultsBuffer( VK_NULL_HANDLE )
+        , m_QueryResultsBufferAllocation( { nullptr } )
+    {
+        // Create the command pool.
+        VkQueryPoolCreateInfo queryPoolCreateInfo = {};
+        queryPoolCreateInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+        queryPoolCreateInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+        queryPoolCreateInfo.queryCount = queryCount;
+
+        m_Profiler.m_pDevice->Callbacks.CreateQueryPool(
+            m_Profiler.m_pDevice->Handle,
+            &queryPoolCreateInfo,
+            nullptr,
+            &m_QueryPool );
+
+#if VKPROF_USE_GPU_TIMESTAMP_BUFFER
+        // Create the staging buffer.
+        VkBufferCreateInfo bufferCreateInfo = {};
+        bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+        bufferCreateInfo.size = queryCount * sizeof( uint64_t );
+
+        m_Profiler.m_pDevice->Callbacks.CreateBuffer(
+            m_Profiler.m_pDevice->Handle,
+            &bufferCreateInfo,
+            nullptr,
+            &m_QueryResultsBuffer );
+
+        // Allocate memory for the buffer.
+        VkMemoryRequirements bufferMemoryRequirements;
+        m_Profiler.m_pDevice->Callbacks.GetBufferMemoryRequirements(
+            m_Profiler.m_pDevice->Handle,
+            m_QueryResultsBuffer,
+            &bufferMemoryRequirements );
+
+        m_Profiler.m_MemoryManager.AllocateMemory(
+            bufferMemoryRequirements,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+            &m_QueryResultsBufferAllocation );
+
+        m_Profiler.m_pDevice->Callbacks.BindBufferMemory(
+            m_Profiler.m_pDevice->Handle,
+            m_QueryResultsBuffer,
+            m_QueryResultsBufferAllocation.m_pPool->m_DeviceMemory,
+            m_QueryResultsBufferAllocation.m_Offset );
+#else
+        m_QueryResultsBufferAllocation.m_Size = sizeof( uint64_t ) * queryCount;
+        m_QueryResultsBufferAllocation.m_pMappedMemory =
+            malloc( m_QueryResultsBufferAllocation.m_Size );
+#endif
+    }
+
+    TimestampQueryPool::~TimestampQueryPool()
+    {
+        if( m_QueryPool != VK_NULL_HANDLE )
+        {
+            m_Profiler.m_pDevice->Callbacks.DestroyQueryPool(
+                m_Profiler.m_pDevice->Handle,
+                m_QueryPool,
+                nullptr );
+        }
+
+#if VKPROF_USE_GPU_TIMESTAMP_BUFFER
+        if( m_QueryResultsBuffer != VK_NULL_HANDLE )
+        {
+            m_Profiler.m_pDevice->Callbacks.DestroyBuffer(
+                m_Profiler.m_pDevice->Handle,
+                m_QueryResultsBuffer,
+                nullptr );
+        }
+
+        if( m_QueryResultsBufferAllocation.m_pPool != nullptr )
+        {
+            m_Profiler.m_MemoryManager.FreeMemory( &m_QueryResultsBufferAllocation );
+        }
+#else
+        free( m_QueryResultsBufferAllocation.m_pMappedMemory );
+#endif
+    }
+
+    void TimestampQueryPool::ResolveQueryDataGpu( VkCommandBuffer commandBuffer, uint32_t queryCount )
+    {
+#if VKPROF_USE_GPU_TIMESTAMP_BUFFER
+        m_Profiler.m_pDevice->Callbacks.CmdCopyQueryPoolResults(
+            commandBuffer,
+            m_QueryPool,
+            0, queryCount,
+            m_QueryResultsBuffer,
+            0, sizeof( uint64_t ),
+            VK_QUERY_RESULT_64_BIT );
+#endif
+    }
+
+    void TimestampQueryPool::ResolveQueryDataCpu( uint32_t queryCount )
+    {
+#if !VKPROF_USE_GPU_TIMESTAMP_BUFFER
+        m_Profiler.m_pDevice->Callbacks.GetQueryPoolResults(
+            m_Profiler.m_pDevice->Handle,
+            m_QueryPool,
+            0, queryCount,
+            m_QueryResultsBufferAllocation.m_Size,
+            m_QueryResultsBufferAllocation.m_pMappedMemory,
+            sizeof( uint64_t ),
+            VK_QUERY_RESULT_64_BIT );
+#endif
+    }
+}

--- a/VkLayer_profiler_layer/profiler/profiler_query_pool.h
+++ b/VkLayer_profiler_layer/profiler/profiler_query_pool.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2022 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include "profiler_memory_manager.h"
+
+#include <vulkan/vk_layer.h>
+
+namespace Profiler
+{
+    class DeviceProfiler;
+
+    class TimestampQueryPool
+    {
+    public:
+        TimestampQueryPool( DeviceProfiler& profiler, uint32_t queryCount );
+        ~TimestampQueryPool();
+
+        TimestampQueryPool( const TimestampQueryPool& ) = delete;
+
+        VkQueryPool GetQueryPoolHandle() const { return m_QueryPool; }
+        VkBuffer GetResultsBufferHandle() const { return m_QueryResultsBuffer; }
+
+        void ResolveQueryDataGpu( VkCommandBuffer, uint32_t );
+        void ResolveQueryDataCpu( uint32_t );
+
+        __forceinline uint64_t GetQueryData( uint32_t queryIndex ) const
+        {
+            return reinterpret_cast<const uint64_t*>( m_QueryResultsBufferAllocation.m_pMappedMemory )[ queryIndex ];
+        }
+
+    private:
+        DeviceProfiler&                m_Profiler;
+
+        VkQueryPool                    m_QueryPool;
+
+        VkBuffer                       m_QueryResultsBuffer;
+        DeviceProfilerMemoryAllocation m_QueryResultsBufferAllocation;
+    };
+}

--- a/VkLayer_profiler_layer/profiler_ext/VkProfilerEXT.cpp
+++ b/VkLayer_profiler_layer/profiler_ext/VkProfilerEXT.cpp
@@ -57,9 +57,9 @@ private:
         delete[] ptr;
     }
 
-    template<typename DataType, typename CallbackType>
+    template<typename DataContainer, typename CallbackType>
     inline VkResult SerializeSubregions(
-        const ContainerType<DataType>& data,
+        const DataContainer& data,
         CallbackType callback,
         VkProfilerRegionDataEXT& out )
     {

--- a/VkLayer_profiler_layer/profiler_helpers/profiler_data_helpers.cpp
+++ b/VkLayer_profiler_layer/profiler_helpers/profiler_data_helpers.cpp
@@ -224,7 +224,22 @@ namespace Profiler
     \***********************************************************************************/
     std::string DeviceProfilerStringSerializer::GetName( const DeviceProfilerRenderPassData& renderPass ) const
     {
-        return GetName( renderPass.m_Handle );
+        if( renderPass.m_Handle != VK_NULL_HANDLE )
+        {
+            return GetName( renderPass.m_Handle );
+        }
+
+        switch (renderPass.m_Type)
+        {
+        case DeviceProfilerRenderPassType::eGraphics:
+            return "Graphics Pass";
+        case DeviceProfilerRenderPassType::eCompute:
+            return "Compute Pass";
+        case DeviceProfilerRenderPassType::eCopy:
+            return "Copy Pass";
+        }
+
+        return "Unknown Pass";
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -1,15 +1,15 @@
 // Copyright (c) 2019-2021 Lukasz Stalmirski
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -256,8 +256,8 @@ namespace Profiler
         if( result == VK_SUCCESS )
         {
             result = (m_pStringSerializer = new (std::nothrow) DeviceProfilerStringSerializer( device ))
-                ? VK_SUCCESS
-                : VK_ERROR_OUT_OF_HOST_MEMORY;
+                         ? VK_SUCCESS
+                         : VK_ERROR_OUT_OF_HOST_MEMORY;
         }
 
         // Don't leave object in partly-initialized state if something went wrong
@@ -372,12 +372,12 @@ namespace Profiler
     \***********************************************************************************/
     bool ProfilerOverlayOutput::IsAvailable() const
     {
-        #ifndef _DEBUG
+#ifndef _DEBUG
         // There are many other objects that could be checked here, but we're keeping
         // object quite consistent in case of any errors during initialization, so
         // checking just one should be sufficient.
         return (m_pSwapchain);
-        #else
+#else
         // Check object state to confirm the note above
         return (m_pSwapchain)
             && (m_pDevice)
@@ -387,7 +387,7 @@ namespace Profiler
             && (m_pImGuiWindowContext)
             && (m_RenderPass)
             && (!m_CommandBuffers.empty());
-        #endif
+#endif
     }
 
     /***********************************************************************************\
@@ -418,8 +418,8 @@ namespace Profiler
         const VkSwapchainCreateInfoKHR* pCreateInfo )
     {
         assert( m_pSwapchain == nullptr ||
-            pCreateInfo->oldSwapchain == m_pSwapchain->Handle ||
-            pCreateInfo->oldSwapchain == VK_NULL_HANDLE );
+                pCreateInfo->oldSwapchain == m_pSwapchain->Handle ||
+                pCreateInfo->oldSwapchain == VK_NULL_HANDLE );
 
         VkResult result = VK_SUCCESS;
 
@@ -636,7 +636,7 @@ namespace Profiler
                 }
             }
         }
-        
+
         // Update objects
         if( result == VK_SUCCESS )
         {
@@ -858,33 +858,33 @@ namespace Profiler
 
         try
         {
-            #ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHR
             if( window.Type == OSWindowHandleType::eWin32 )
             {
                 m_pImGuiWindowContext = new ImGui_ImplWin32_Context( window.Win32Handle );
             }
-            #endif // VK_USE_PLATFORM_WIN32_KHR
+#endif // VK_USE_PLATFORM_WIN32_KHR
 
-            #ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
             if( window.Type == OSWindowHandleType::eWayland )
             {
                 m_pImGuiWindowContext = new ImGui_ImplWayland_Context( window.WaylandHandle );
             }
-            #endif // VK_USE_PLATFORM_WAYLAND_KHR
+#endif // VK_USE_PLATFORM_WAYLAND_KHR
 
-            #ifdef VK_USE_PLATFORM_XCB_KHR
+#ifdef VK_USE_PLATFORM_XCB_KHR
             if( window.Type == OSWindowHandleType::eXcb )
             {
                 m_pImGuiWindowContext = new ImGui_ImplXcb_Context( window.XcbHandle );
             }
-            #endif // VK_USE_PLATFORM_XCB_KHR
+#endif // VK_USE_PLATFORM_XCB_KHR
 
-            #ifdef VK_USE_PLATFORM_XLIB_KHR
+#ifdef VK_USE_PLATFORM_XLIB_KHR
             if( window.Type == OSWindowHandleType::eXlib )
             {
                 m_pImGuiWindowContext = new ImGui_ImplXlib_Context( window.XlibHandle );
             }
-            #endif // VK_USE_PLATFORM_XLIB_KHR
+#endif // VK_USE_PLATFORM_XLIB_KHR
         }
         catch( ... )
         {
@@ -920,7 +920,7 @@ namespace Profiler
         // Absolute path to the selected font
         std::filesystem::path fontPath;
 
-        #ifdef WIN32
+#ifdef WIN32
         {
             // Locate system fonts directory
             std::filesystem::path fontsPath;
@@ -946,8 +946,8 @@ namespace Profiler
                 else fontPath = "";
             }
         }
-        #endif
-        #ifdef __linux__
+#endif
+#ifdef __linux__
         {
             // Linux distros use multiple font directories (or X server, TODO)
             std::vector<std::filesystem::path> fontDirectories = {
@@ -1014,7 +1014,7 @@ namespace Profiler
                     break;
             }
         }
-        #endif
+#endif
 
         if( !fontPath.empty() )
         {
@@ -1239,7 +1239,7 @@ namespace Profiler
 
                     ImGui::Text( "%2u. %s", i + 1, m_pStringSerializer->GetName( pipeline ).c_str() );
                     ImGuiX::TextAlignRight( "(%.1f %%) %.2f ms",
-                        pipelineTicks * 100.f / m_Data.m_Ticks, 
+                        pipelineTicks * 100.f / m_Data.m_Ticks,
                         pipelineTicks * m_TimestampPeriod.count() );
 
                     // Print up to 10 top pipelines
@@ -1257,8 +1257,8 @@ namespace Profiler
             ImGui::BeginTable( "Performance counters table",
                 /* columns_count */ 3,
                 ImGuiTableFlags_Resizable |
-                ImGuiTableFlags_NoClip |
-                ImGuiTableFlags_Borders );
+                    ImGuiTableFlags_NoClip |
+                    ImGuiTableFlags_Borders );
 
             // Headers
             ImGui::TableSetupColumn( Lang::Metric, ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize );
@@ -1411,8 +1411,8 @@ namespace Profiler
                 }
 
                 if( ImGui::TreeNode( indexStr, "vkQueueSubmit(%s, %u)",
-                    queueName.c_str(),
-                    static_cast<uint32_t>(submitBatch.m_Submits.size()) ) )
+                        queueName.c_str(),
+                        static_cast<uint32_t>(submitBatch.m_Submits.size()) ) )
                 {
                     for( const auto& submit : submitBatch.m_Submits )
                     {
@@ -1539,7 +1539,7 @@ namespace Profiler
                         std::stringstream sstr;
 
                         sstr << Lang::MemoryTypeIndex << " " << typeIndex << "\n"
-                            << m_Data.m_Memory.m_Types[ typeIndex ].m_AllocationCount << " " << Lang::Allocations << "\n";
+                             << m_Data.m_Memory.m_Types[ typeIndex ].m_AllocationCount << " " << Lang::Allocations << "\n";
 
                         if( memoryProperties.memoryTypes[ typeIndex ].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT )
                         {
@@ -2044,7 +2044,7 @@ namespace Profiler
 
             const float fadeOutStep =
                 1.f - std::max( 0.f, std::min( 1.f,
-                    duration_cast<milliseconds>(now - (m_SerializationFinishTimestamp + 3s)).count() / 1000.f ) );
+                                         duration_cast<milliseconds>(now - (m_SerializationFinishTimestamp + 3s)).count() / 1000.f ) );
 
             ImGui::PushStyleVar( ImGuiStyleVar_Alpha, fadeOutStep );
 
@@ -2056,11 +2056,11 @@ namespace Profiler
             ImGui::SetNextWindowPos( windowPos );
             ImGui::Begin( "Trace Export", nullptr,
                 ImGuiWindowFlags_NoMove |
-                ImGuiWindowFlags_NoResize |
-                ImGuiWindowFlags_NoTitleBar |
-                ImGuiWindowFlags_NoCollapse |
-                ImGuiWindowFlags_NoSavedSettings |
-                ImGuiWindowFlags_AlwaysAutoResize );
+                    ImGuiWindowFlags_NoResize |
+                    ImGuiWindowFlags_NoTitleBar |
+                    ImGuiWindowFlags_NoCollapse |
+                    ImGuiWindowFlags_NoSavedSettings |
+                    ImGuiWindowFlags_AlwaysAutoResize );
 
             ImGui::Text( "%s", m_SerializationMessage.c_str() );
 
@@ -2108,12 +2108,12 @@ namespace Profiler
             (m_SelectedFrameBrowserNodeIndex.SubmitBatchIndex == index.SubmitBatchIndex) &&
             (m_SelectedFrameBrowserNodeIndex.SubmitIndex == index.SubmitIndex) &&
             (((cmdBuffer.m_Level == VK_COMMAND_BUFFER_LEVEL_PRIMARY) &&
-                (m_SelectedFrameBrowserNodeIndex.PrimaryCommandBufferIndex == index.PrimaryCommandBufferIndex)) ||
-            ((cmdBuffer.m_Level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) &&
-                (m_SelectedFrameBrowserNodeIndex.PrimaryCommandBufferIndex == index.PrimaryCommandBufferIndex) &&
-                (m_SelectedFrameBrowserNodeIndex.RenderPassIndex == index.RenderPassIndex) &&
-                (m_SelectedFrameBrowserNodeIndex.SubpassIndex == index.SubpassIndex) &&
-                (m_SelectedFrameBrowserNodeIndex.SecondaryCommandBufferIndex == index.SecondaryCommandBufferIndex))) )
+                  (m_SelectedFrameBrowserNodeIndex.PrimaryCommandBufferIndex == index.PrimaryCommandBufferIndex)) ||
+                ((cmdBuffer.m_Level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) &&
+                    (m_SelectedFrameBrowserNodeIndex.PrimaryCommandBufferIndex == index.PrimaryCommandBufferIndex) &&
+                    (m_SelectedFrameBrowserNodeIndex.RenderPassIndex == index.RenderPassIndex) &&
+                    (m_SelectedFrameBrowserNodeIndex.SubpassIndex == index.SubpassIndex) &&
+                    (m_SelectedFrameBrowserNodeIndex.SecondaryCommandBufferIndex == index.SecondaryCommandBufferIndex))) )
         {
             // Tree contains selected node
             ImGui::SetNextItemOpen( true );
@@ -2123,7 +2123,7 @@ namespace Profiler
         if( ImGui::TreeNode( indexStr, "%s", m_pStringSerializer->GetName( cmdBuffer.m_Handle ).c_str() ) )
         {
             // Command buffer opened
-            ImGuiX::TextAlignRight( "%.2f ms", commandBufferTicks * m_TimestampPeriod.count() );
+            PrintDuration( commandBufferTicks, VK_PROFILER_MODE_PER_COMMAND_BUFFER_EXT );
 
             // Sort frame browser data
             std::list<const DeviceProfilerRenderPassData*> pRenderPasses =
@@ -2149,7 +2149,7 @@ namespace Profiler
         else
         {
             // Command buffer collapsed
-            ImGuiX::TextAlignRight( "%.2f ms", commandBufferTicks * m_TimestampPeriod.count() );
+            PrintDuration( commandBufferTicks, VK_PROFILER_MODE_PER_COMMAND_BUFFER_EXT );
         }
     }
 
@@ -2164,7 +2164,7 @@ namespace Profiler
     \***********************************************************************************/
     void ProfilerOverlayOutput::PrintRenderPass( const DeviceProfilerRenderPassData& renderPass, FrameBrowserTreeNodeIndex index )
     {
-        const uint64_t renderPassTicks = (renderPass.m_EndTimestamp - renderPass.m_BeginTimestamp);
+        const uint64_t renderPassTicks = (renderPass.m_EndTimestamp - renderPass.m_BeginTimestamp );
 
         // Mark hotspots with color
         DrawSignificanceRect( (float)renderPassTicks / m_Data.m_Ticks, index );
@@ -2189,38 +2189,37 @@ namespace Profiler
         }
 
         const bool inRenderPassSubtree =
-            (renderPass.m_Handle != VK_NULL_HANDLE) &&
-            (ImGui::TreeNode( indexStr, "%s",
-                m_pStringSerializer->GetName( renderPass.m_Handle ).c_str() ));
+            ImGui::TreeNode( indexStr, "%s",
+                m_pStringSerializer->GetName( renderPass ).c_str() );
 
         if( inRenderPassSubtree )
         {
-            const uint64_t renderPassBeginTicks = (renderPass.m_Begin.m_EndTimestamp - renderPass.m_Begin.m_BeginTimestamp);
-
             // Render pass subtree opened
-            ImGuiX::TextAlignRight( "%.2f ms", renderPassTicks * m_TimestampPeriod.count() );
+            PrintDuration( renderPassTicks, VK_PROFILER_MODE_PER_RENDER_PASS_EXT );
 
-            index.DrawcallIndex = 0;
-
-            if( (m_ScrollToSelectedFrameBrowserNode) &&
-                (m_SelectedFrameBrowserNodeIndex == index) )
+            if( renderPass.m_Handle != VK_NULL_HANDLE )
             {
-                ImGui::SetScrollHereY();
+                const uint64_t renderPassBeginTicks = (renderPass.m_Begin.m_EndTimestamp - renderPass.m_Begin.m_BeginTimestamp);
+
+                index.DrawcallIndex = 0;
+
+                if( (m_ScrollToSelectedFrameBrowserNode) &&
+                    (m_SelectedFrameBrowserNodeIndex == index) )
+                {
+                    ImGui::SetScrollHereY();
+                }
+
+                // Mark hotspots with color
+                DrawSignificanceRect( (float)renderPassBeginTicks / m_Data.m_Ticks, index );
+
+                index.DrawcallIndex = 0xFFFF;
+
+                // Print BeginRenderPass pipeline
+                ImGui::TextUnformatted( "vkCmdBeginRenderPass" );
+
+                PrintDuration( renderPassBeginTicks, VK_PROFILER_MODE_PER_PIPELINE_EXT );
             }
 
-            // Mark hotspots with color
-            DrawSignificanceRect( (float)renderPassBeginTicks / m_Data.m_Ticks, index );
-
-            index.DrawcallIndex = 0xFFFF;
-
-            // Print BeginRenderPass pipeline
-            ImGui::TextUnformatted( "vkCmdBeginRenderPass" );
-            ImGuiX::TextAlignRight( "%.2f ms", renderPassBeginTicks * m_TimestampPeriod.count() );
-        }
-
-        if( inRenderPassSubtree ||
-            (renderPass.m_Handle == VK_NULL_HANDLE) )
-        {
             // Sort frame browser data
             std::list<const DeviceProfilerSubpassData*> pSubpasses =
                 SortFrameBrowserData( renderPass.m_Subpasses );
@@ -2244,37 +2243,37 @@ namespace Profiler
             {
                 index.SubpassIndex = 0xFFFF;
             }
-        }
 
-        if( inRenderPassSubtree )
-        {
-            const uint64_t renderPassEndTicks = (renderPass.m_End.m_EndTimestamp - renderPass.m_End.m_BeginTimestamp);
-
-            index.DrawcallIndex = 1;
-
-            if( (m_ScrollToSelectedFrameBrowserNode) &&
-                (m_SelectedFrameBrowserNodeIndex == index) )
+            if( renderPass.m_Handle != VK_NULL_HANDLE )
             {
-                ImGui::SetScrollHereY();
+                const uint64_t renderPassEndTicks = (renderPass.m_End.m_EndTimestamp - renderPass.m_End.m_BeginTimestamp);
+
+                index.DrawcallIndex = 1;
+
+                if( (m_ScrollToSelectedFrameBrowserNode) &&
+                    (m_SelectedFrameBrowserNodeIndex == index) )
+                {
+                    ImGui::SetScrollHereY();
+                }
+
+                // Mark hotspots with color
+                DrawSignificanceRect( (float)renderPassEndTicks / m_Data.m_Ticks, index );
+
+                index.DrawcallIndex = 0xFFFF;
+
+                // Print EndRenderPass pipeline
+                ImGui::TextUnformatted( "vkCmdEndRenderPass" );
+
+                PrintDuration( renderPassEndTicks, VK_PROFILER_MODE_PER_PIPELINE_EXT );
             }
-
-            // Mark hotspots with color
-            DrawSignificanceRect( (float)renderPassEndTicks / m_Data.m_Ticks, index );
-
-            index.DrawcallIndex = 0xFFFF;
-
-            // Print EndRenderPass pipeline
-            ImGui::TextUnformatted( "vkCmdEndRenderPass" );
-            ImGuiX::TextAlignRight( "%.2f ms", renderPassEndTicks * m_TimestampPeriod.count() );
 
             ImGui::TreePop();
         }
 
-        if( !inRenderPassSubtree &&
-            (renderPass.m_Handle != VK_NULL_HANDLE) )
+        if( !inRenderPassSubtree )
         {
             // Render pass collapsed
-            ImGuiX::TextAlignRight( "%.2f ms", renderPassTicks * m_TimestampPeriod.count() );
+            PrintDuration( renderPassTicks, VK_PROFILER_MODE_PER_RENDER_PASS_EXT );
         }
     }
 
@@ -2321,7 +2320,7 @@ namespace Profiler
         if( inSubpassSubtree )
         {
             // Subpass subtree opened
-            ImGuiX::TextAlignRight( "%.2f ms", subpassTicks * m_TimestampPeriod.count() );
+            PrintDuration( subpassTicks, VK_PROFILER_MODE_PER_RENDER_PASS_EXT );
         }
 
         if( inSubpassSubtree ||
@@ -2370,7 +2369,7 @@ namespace Profiler
         if( !inSubpassSubtree && !isOnlySubpass && (subpass.m_Index != -1) )
         {
             // Subpass collapsed
-            ImGuiX::TextAlignRight( "%.2f ms", subpassTicks * m_TimestampPeriod.count() );
+            PrintDuration( subpassTicks, VK_PROFILER_MODE_PER_RENDER_PASS_EXT );
         }
     }
 
@@ -2422,7 +2421,7 @@ namespace Profiler
         if( inPipelineSubtree )
         {
             // Pipeline subtree opened
-            ImGuiX::TextAlignRight( "%.2f ms", pipelineTicks * m_TimestampPeriod.count() );
+            PrintDuration( pipelineTicks, VK_PROFILER_MODE_PER_PIPELINE_EXT );
         }
 
         if( inPipelineSubtree || printPipelineInline )
@@ -2450,7 +2449,7 @@ namespace Profiler
         if( !inPipelineSubtree && !printPipelineInline )
         {
             // Pipeline collapsed
-            ImGuiX::TextAlignRight( "%.2f ms", pipelineTicks * m_TimestampPeriod.count() );
+            PrintDuration( pipelineTicks, VK_PROFILER_MODE_PER_PIPELINE_EXT );
         }
     }
 
@@ -2481,13 +2480,36 @@ namespace Profiler
             const std::string drawcallString = m_pStringSerializer->GetName( drawcall );
             ImGui::TextUnformatted( drawcallString.c_str() );
 
-            // Print drawcall duration
-            ImGuiX::TextAlignRight( "%.2f ms", drawcallTicks * m_TimestampPeriod.count() );
+            PrintDuration( drawcallTicks, VK_PROFILER_MODE_PER_DRAWCALL_EXT );
         }
         else
         {
             // Draw debug label
             PrintDebugLabel( drawcall.m_Payload.m_DebugLabel.m_pName, drawcall.m_Payload.m_DebugLabel.m_Color );
+        }
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        PrintDuration
+
+    Description:
+        Writes a duration label.
+        The label is written only if current sampling mode is at least minRequiredMode.
+
+    \***********************************************************************************/
+    void ProfilerOverlayOutput::PrintDuration( uint64_t ticks, VkProfilerModeEXT minRequiredMode )
+    {
+        if( m_Data.m_SamplingMode <= minRequiredMode )
+        {
+            // Print the duration
+            ImGuiX::TextAlignRight( "%.2f ms", ticks * m_TimestampPeriod.count() );
+        }
+        else
+        {
+            // No data collected in this mode
+            ImGuiX::TextAlignRight( "- ms" );
         }
     }
 
@@ -2522,7 +2544,7 @@ namespace Profiler
             // Interpolate color
             auto now = std::chrono::high_resolution_clock::now();
             float step = std::max( 0.0f, std::min( 1.0f,
-                duration_cast<Milliseconds>((now - m_SelectionUpdateTimestamp) - 0.3s).count() / 1000.0f ) );
+                                             duration_cast<Milliseconds>((now - m_SelectionUpdateTimestamp) - 0.3s).count() / 1000.0f ) );
 
             // Linear interpolation
             color = ImGuiX::ColorLerp( selectionColor, color, step );

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -2123,7 +2123,7 @@ namespace Profiler
         if( ImGui::TreeNode( indexStr, "%s", m_pStringSerializer->GetName( cmdBuffer.m_Handle ).c_str() ) )
         {
             // Command buffer opened
-            PrintDuration( commandBufferTicks, VK_PROFILER_MODE_PER_COMMAND_BUFFER_EXT );
+            PrintDuration( cmdBuffer );
 
             // Sort frame browser data
             std::list<const DeviceProfilerRenderPassData*> pRenderPasses =
@@ -2149,7 +2149,7 @@ namespace Profiler
         else
         {
             // Command buffer collapsed
-            PrintDuration( commandBufferTicks, VK_PROFILER_MODE_PER_COMMAND_BUFFER_EXT );
+            PrintDuration( cmdBuffer );
         }
     }
 
@@ -2195,7 +2195,7 @@ namespace Profiler
         if( inRenderPassSubtree )
         {
             // Render pass subtree opened
-            PrintDuration( renderPassTicks, VK_PROFILER_MODE_PER_RENDER_PASS_EXT );
+            PrintDuration( renderPass );
 
             if( renderPass.m_Handle != VK_NULL_HANDLE )
             {
@@ -2217,7 +2217,7 @@ namespace Profiler
                 // Print BeginRenderPass pipeline
                 ImGui::TextUnformatted( "vkCmdBeginRenderPass" );
 
-                PrintDuration( renderPassBeginTicks, VK_PROFILER_MODE_PER_PIPELINE_EXT );
+                PrintDuration( renderPass.m_Begin );
             }
 
             // Sort frame browser data
@@ -2264,7 +2264,7 @@ namespace Profiler
                 // Print EndRenderPass pipeline
                 ImGui::TextUnformatted( "vkCmdEndRenderPass" );
 
-                PrintDuration( renderPassEndTicks, VK_PROFILER_MODE_PER_PIPELINE_EXT );
+                PrintDuration( renderPass.m_End );
             }
 
             ImGui::TreePop();
@@ -2273,7 +2273,7 @@ namespace Profiler
         if( !inRenderPassSubtree )
         {
             // Render pass collapsed
-            PrintDuration( renderPassTicks, VK_PROFILER_MODE_PER_RENDER_PASS_EXT );
+            PrintDuration( renderPass );
         }
     }
 
@@ -2320,7 +2320,7 @@ namespace Profiler
         if( inSubpassSubtree )
         {
             // Subpass subtree opened
-            PrintDuration( subpassTicks, VK_PROFILER_MODE_PER_RENDER_PASS_EXT );
+            PrintDuration( subpass );
         }
 
         if( inSubpassSubtree ||
@@ -2369,7 +2369,7 @@ namespace Profiler
         if( !inSubpassSubtree && !isOnlySubpass && (subpass.m_Index != -1) )
         {
             // Subpass collapsed
-            PrintDuration( subpassTicks, VK_PROFILER_MODE_PER_RENDER_PASS_EXT );
+            PrintDuration( subpass );
         }
     }
 
@@ -2421,7 +2421,7 @@ namespace Profiler
         if( inPipelineSubtree )
         {
             // Pipeline subtree opened
-            PrintDuration( pipelineTicks, VK_PROFILER_MODE_PER_PIPELINE_EXT );
+            PrintDuration( pipeline );
         }
 
         if( inPipelineSubtree || printPipelineInline )
@@ -2449,7 +2449,7 @@ namespace Profiler
         if( !inPipelineSubtree && !printPipelineInline )
         {
             // Pipeline collapsed
-            PrintDuration( pipelineTicks, VK_PROFILER_MODE_PER_PIPELINE_EXT );
+            PrintDuration( pipeline );
         }
     }
 
@@ -2480,36 +2480,12 @@ namespace Profiler
             const std::string drawcallString = m_pStringSerializer->GetName( drawcall );
             ImGui::TextUnformatted( drawcallString.c_str() );
 
-            PrintDuration( drawcallTicks, VK_PROFILER_MODE_PER_DRAWCALL_EXT );
+            PrintDuration( drawcall );
         }
         else
         {
             // Draw debug label
             PrintDebugLabel( drawcall.m_Payload.m_DebugLabel.m_pName, drawcall.m_Payload.m_DebugLabel.m_Color );
-        }
-    }
-
-    /***********************************************************************************\
-
-    Function:
-        PrintDuration
-
-    Description:
-        Writes a duration label.
-        The label is written only if current sampling mode is at least minRequiredMode.
-
-    \***********************************************************************************/
-    void ProfilerOverlayOutput::PrintDuration( uint64_t ticks, VkProfilerModeEXT minRequiredMode )
-    {
-        if( m_Data.m_SamplingMode <= minRequiredMode )
-        {
-            // Print the duration
-            ImGuiX::TextAlignRight( "%.2f ms", ticks * m_TimestampPeriod.count() );
-        }
-        else
-        {
-            // No data collected in this mode
-            ImGuiX::TextAlignRight( "- ms" );
         }
     }
 

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
@@ -219,6 +219,7 @@ namespace Profiler
         void PrintPipeline( const DeviceProfilerPipelineData&, FrameBrowserTreeNodeIndex );
         void PrintDrawcall( const DeviceProfilerDrawcall&, FrameBrowserTreeNodeIndex );
         void PrintDebugLabel( const char*, const float[ 4 ] );
+        void PrintDuration( uint64_t, VkProfilerModeEXT );
 
         void DrawSignificanceRect( float, const FrameBrowserTreeNodeIndex& );
 

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
@@ -219,17 +219,34 @@ namespace Profiler
         void PrintPipeline( const DeviceProfilerPipelineData&, FrameBrowserTreeNodeIndex );
         void PrintDrawcall( const DeviceProfilerDrawcall&, FrameBrowserTreeNodeIndex );
         void PrintDebugLabel( const char*, const float[ 4 ] );
-        void PrintDuration( uint64_t, VkProfilerModeEXT );
 
         void DrawSignificanceRect( float, const FrameBrowserTreeNodeIndex& );
 
+        template<typename Data>
+        void PrintDuration( const Data& data )
+        {
+            if( (data.m_BeginTimestamp != UINT64_MAX) && (data.m_EndTimestamp != UINT64_MAX) )
+            {
+                const uint64_t ticks = data.m_EndTimestamp - data.m_BeginTimestamp;
+
+                // Print the duration
+                ImGuiX::TextAlignRight( "%.2f ms", ticks * m_TimestampPeriod.count() );
+            }
+            else
+            {
+                // No data collected in this mode
+                ImGuiX::TextAlignRight( "- ms" );
+            }
+        }
+
         // Sort frame browser data
         template<typename Data>
-        std::list<const Data*> SortFrameBrowserData( const ContainerType<Data>& data ) const
+        auto SortFrameBrowserData( const Data& data ) const
         {
-            std::list<const Data*> pSortedData;
+            using Subdata = typename Data::value_type;
+            std::list<const Subdata*> pSortedData;
 
-            for( const Data& subdata : data )
+            for( const auto& subdata : data )
                 pSortedData.push_back( &subdata );
 
             switch( m_FrameBrowserSortMode )
@@ -238,11 +255,11 @@ namespace Profiler
                 break; // No sorting in submission order view
 
             case FrameBrowserSortMode::eDurationDescending:
-                pSortedData.sort( []( const Data* a, const Data* b )
+                pSortedData.sort( []( const Subdata* a, const Subdata* b )
                     { return DurationDesc( *a, *b ); } ); break;
 
             case FrameBrowserSortMode::eDurationAscending:
-                pSortedData.sort( []( const Data* a, const Data* b )
+                pSortedData.sort( []( const Subdata* a, const Subdata* b )
                     { return DurationAsc( *a, *b ); } ); break;
             }
 


### PR DESCRIPTION
Previously the profiler sampled always at the drawcall level. This introduced a significant overhead that rendered the per-pipeline and per-renderpass measurements unreliable. With new sampling modes, a high-level data can be obtained without impacting the performance of the measured regions.

This change implements already existing sampling modes that were present in VkProfilerExt.h:
- VK_PROFILER_MODE_PER_DRAWCALL_EXT (default)
- VK_PROFILER_MODE_PER_PIPELINE_EXT
- VK_PROFILER_MODE_PER_RENDER_PASS_EXT
- VK_PROFILER_MODE_PER_COMMAND_BUFFER_EXT

Sampling mode can be selected via environment variable VKPROF_SAMPLING_MODE: "DRAW", "PIPELINE", "RENDERPASS" or "COMMANDBUFFER".