### PR TITLE
Fix compilation errors on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ if (UNIX)
     #find_package (Wayland)
     find_package (XCB REQUIRED COMPONENTS XCB SHAPE)
     find_package (X11 REQUIRED)
+
+    # Export symbols explicitly
+    set (CMAKE_CXX_VISIBILITY_PRESET hidden)
+    set (CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 endif ()
 
 # Build with C++17

--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -1121,7 +1121,7 @@ namespace Profiler
         }
 
         char pObjectDebugName[ 64 ] = {};
-        sprintf_s( pObjectDebugName, "%s 0x%016llx", object.m_pTypeName, object.m_Handle );
+        ProfilerStringFunctions::Format( pObjectDebugName, "%s 0x%016llx", object.m_pTypeName, object.m_Handle );
 
         m_pDevice->Debug.ObjectNames.insert( object, pObjectDebugName );
     }

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
@@ -842,14 +842,7 @@ namespace Profiler
                 }
             }
 
-            volatile const uint64_t endTimestampIndex = m_Data.m_EndTimestamp;
-
-            m_Data.m_EndTimestamp = m_pQueryPool->GetTimestampData( endTimestampIndex );
-
-            if( m_Data.m_EndTimestamp < m_Data.m_BeginTimestamp )
-            {
-                __debugbreak();
-            }
+            m_Data.m_EndTimestamp = m_pQueryPool->GetTimestampData( m_Data.m_EndTimestamp );
 
             // Read vendor-specific data
             if( auto performanceQueryPool = m_pQueryPool->GetPerformanceQueryPoolHandle() )

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.h
@@ -51,7 +51,7 @@ namespace Profiler
 
         VkQueryPool GetPerformanceQueryPoolHandle() const { return m_PerformanceQueryPoolINTEL; }
 
-        __forceinline void PreallocateQueries( VkCommandBuffer commandBuffer )
+        PROFILER_FORCE_INLINE void PreallocateQueries( VkCommandBuffer commandBuffer )
         {
             if( ( m_pQueryPools.empty() ) ||
                 ( ( m_CurrentQueryPoolIndex == m_pQueryPools.size() ) &&
@@ -62,7 +62,7 @@ namespace Profiler
             }
         }
 
-        __forceinline void Reset( VkCommandBuffer commandBuffer )
+        PROFILER_FORCE_INLINE void Reset( VkCommandBuffer commandBuffer )
         {
             // Reset the full query pools.
             for( uint32_t queryPoolIndex = 0; queryPoolIndex < m_CurrentQueryPoolIndex; ++queryPoolIndex )
@@ -86,7 +86,7 @@ namespace Profiler
             m_CurrentQueryPoolIndex = 0;
         }
 
-        __forceinline void ResolveTimestampsGpu( VkCommandBuffer commandBuffer )
+        PROFILER_FORCE_INLINE void ResolveTimestampsGpu( VkCommandBuffer commandBuffer )
         {
             // Copy data from the full query pools.
             for( uint32_t queryPoolIndex = 0; queryPoolIndex < m_CurrentQueryPoolIndex; ++queryPoolIndex )
@@ -101,7 +101,7 @@ namespace Profiler
             }
         }
 
-        __forceinline void ResolveTimestampsCpu()
+        PROFILER_FORCE_INLINE void ResolveTimestampsCpu()
         {
             // Copy data from the full query pools.
             for( uint32_t queryPoolIndex = 0; queryPoolIndex < m_CurrentQueryPoolIndex; ++queryPoolIndex )
@@ -116,7 +116,7 @@ namespace Profiler
             }
         }
 
-        __forceinline uint64_t WriteTimestamp( VkCommandBuffer commandBuffer, VkPipelineStageFlagBits stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT )
+        PROFILER_FORCE_INLINE uint64_t WriteTimestamp( VkCommandBuffer commandBuffer, VkPipelineStageFlagBits stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT )
         {
             // Allocate query from the pool
             m_CurrentQueryIndex++;
@@ -145,7 +145,7 @@ namespace Profiler
                    ( static_cast<uint64_t>( m_CurrentQueryIndex ) & 0xFFFFFFFF );
         }
 
-        __forceinline uint64_t GetTimestampData( uint64_t query ) const
+        PROFILER_FORCE_INLINE uint64_t GetTimestampData( uint64_t query ) const
         {
             const uint32_t queryPoolIndex = static_cast<uint32_t>( query >> 32 );
             const uint32_t queryIndex = static_cast<uint32_t>( query & 0xFFFFFFFF );
@@ -164,7 +164,7 @@ namespace Profiler
 
         VkQueryPool                      m_PerformanceQueryPoolINTEL;
 
-        __forceinline void AllocateQueryPool( VkCommandBuffer commandBuffer )
+        PROFILER_FORCE_INLINE void AllocateQueryPool( VkCommandBuffer commandBuffer )
         {
             auto* pQueryPool = m_pQueryPools.emplace_back(
                 new TimestampQueryPool( m_Profiler, m_QueryPoolSize ) );

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -503,7 +503,7 @@ namespace Profiler
             if( dc.GetPipelineType() == DeviceProfilerPipelineType::eDebug )
             {
                 // Create copy of already stored string
-                m_Payload.m_DebugLabel.m_pName = _strdup( dc.m_Payload.m_DebugLabel.m_pName );
+                m_Payload.m_DebugLabel.m_pName = ProfilerStringFunctions::DuplicateString( dc.m_Payload.m_DebugLabel.m_pName );
             }
 
             if( dc.m_Type == DeviceProfilerDrawcallType::eBuildAccelerationStructuresKHR )

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
@@ -24,6 +24,7 @@
 #include "profiler_layer_objects/VkDevice_object.h"
 #include "intel/profiler_metrics_api.h"
 #include <assert.h>
+#include <algorithm>
 #include <unordered_set>
 
 namespace Profiler

--- a/VkLayer_profiler_layer/profiler/profiler_helpers.h
+++ b/VkLayer_profiler_layer/profiler/profiler_helpers.h
@@ -59,6 +59,15 @@
 #define PROFILER_MAKE_STRING_IMPL( LIT ) #LIT
 #define PROFILER_MAKE_STRING( LIT ) PROFILER_MAKE_STRING_IMPL( LIT )
 
+// Force inlining of some functions for performance reasons
+#if defined( _MSC_VER )
+#define PROFILER_FORCE_INLINE __forceinline
+#elif defined( __GNUC__ )
+#define PROFILER_FORCE_INLINE inline __attribute__((always_inline))
+#else
+#define PROFILER_FORCE_INLINE inline
+#endif
+
 namespace Profiler
 {
     /***********************************************************************************\
@@ -71,7 +80,7 @@ namespace Profiler
 
     \***********************************************************************************/
     template<typename T>
-    void ClearMemory( T* pMemory )
+    PROFILER_FORCE_INLINE void ClearMemory( T* pMemory )
     {
         memset( pMemory, 0, sizeof( T ) );
     }
@@ -86,7 +95,7 @@ namespace Profiler
 
     \***********************************************************************************/
     template<typename T>
-    void ClearStructure( T* pStruct, VkStructureType type )
+    PROFILER_FORCE_INLINE void ClearStructure( T* pStruct, VkStructureType type )
     {
         memset( pStruct, 0, sizeof( T ) );
         pStruct->sType = type;
@@ -101,7 +110,7 @@ namespace Profiler
         Convert 8-bit unsigned number to hexadecimal string.
 
     \***********************************************************************************/
-    inline void u8tohex( char* pBuffer, uint8_t value )
+    PROFILER_FORCE_INLINE void u8tohex( char* pBuffer, uint8_t value )
     {
         static const char hexDigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
         static_assert(sizeof( hexDigits ) == 16);
@@ -124,7 +133,7 @@ namespace Profiler
         Convert 16-bit unsigned number to hexadecimal string.
 
     \***********************************************************************************/
-    inline void u16tohex( char* pBuffer, uint16_t value )
+    PROFILER_FORCE_INLINE void u16tohex( char* pBuffer, uint16_t value )
     {
         static const char hexDigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
         static_assert(sizeof( hexDigits ) == 16);
@@ -147,7 +156,7 @@ namespace Profiler
         Convert 32-bit unsigned number to hexadecimal string.
 
     \***********************************************************************************/
-    inline void u32tohex( char* pBuffer, uint32_t value )
+    PROFILER_FORCE_INLINE void u32tohex( char* pBuffer, uint32_t value )
     {
         static const char hexDigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
         static_assert( sizeof( hexDigits ) == 16 );
@@ -170,7 +179,7 @@ namespace Profiler
         Convert 64-bit unsigned number to hexadecimal string.
 
     \***********************************************************************************/
-    inline void u64tohex( char* pBuffer, uint64_t value )
+    PROFILER_FORCE_INLINE void u64tohex( char* pBuffer, uint64_t value )
     {
         static const char hexDigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
         static_assert( sizeof( hexDigits ) == 16 );
@@ -194,7 +203,7 @@ namespace Profiler
 
     \***********************************************************************************/
     template<typename T, size_t Size>
-    inline void structtohex( char( &pBuffer )[ Size ], const T& value )
+    PROFILER_FORCE_INLINE void structtohex( char( &pBuffer )[ Size ], const T& value )
     {
         static const char hexDigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
         static_assert(sizeof( hexDigits ) == 16);
@@ -219,7 +228,7 @@ namespace Profiler
 
     \***********************************************************************************/
     template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-    uint32_t DigitCount( T value )
+    PROFILER_FORCE_INLINE uint32_t DigitCount( T value )
     {
         if( value == 0 )
         {
@@ -409,6 +418,27 @@ namespace Profiler
     \***********************************************************************************/
     struct ProfilerStringFunctions
     {
+        template<size_t dstSize, typename... ArgsT>
+        static void Format( char( &dst )[ dstSize ], const char* fmt, ArgsT... args )
+        {
+#if defined( _MSC_VER )
+            sprintf_s( dst, fmt, args... );
+#else
+            sprintf( dst, fmt, args... );
+#endif
+        }
+        
+        template<typename... ArgsT>
+        static void Format( char* dst, size_t dstSize, const char* fmt, ArgsT... args )
+        {
+#if defined( _MSC_VER )
+            sprintf_s( dst, dstSize, fmt, args... );
+#else
+            (void) dstSize;
+            sprintf( dst, fmt, args... );
+#endif
+        }
+
         template<typename CharT>
         static void CopyString( CharT* pDst, size_t dstSize, const CharT* pSrc, size_t srcSize )
         {
@@ -566,7 +596,7 @@ namespace Profiler
 
     \***********************************************************************************/
     template<typename T>
-    inline T* CopyElements(uint32_t count, const T* pElements)
+    PROFILER_FORCE_INLINE T* CopyElements(uint32_t count, const T* pElements)
     {
         T* pDuplicated = nullptr;
         if (count > 0)
@@ -578,5 +608,24 @@ namespace Profiler
             }
         }
         return pDuplicated;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        MakeVector
+
+    Description:
+        Creates an std::vector preinitialized with <count> elements.
+
+    \***********************************************************************************/
+    template<typename T>
+    PROFILER_FORCE_INLINE std::vector<T> MakeVector(uint32_t count, const T* pElements)
+    {
+        if (count > 0)
+        {
+            return std::vector<T>(pElements, pElements + count);
+        }
+        return {};
     }
 }

--- a/VkLayer_profiler_layer/profiler/profiler_helpers.h
+++ b/VkLayer_profiler_layer/profiler/profiler_helpers.h
@@ -609,23 +609,4 @@ namespace Profiler
         }
         return pDuplicated;
     }
-
-    /***********************************************************************************\
-
-    Function:
-        MakeVector
-
-    Description:
-        Creates an std::vector preinitialized with <count> elements.
-
-    \***********************************************************************************/
-    template<typename T>
-    PROFILER_FORCE_INLINE std::vector<T> MakeVector(uint32_t count, const T* pElements)
-    {
-        if (count > 0)
-        {
-            return std::vector<T>(pElements, pElements + count);
-        }
-        return {};
-    }
 }

--- a/VkLayer_profiler_layer/profiler/profiler_query_pool.h
+++ b/VkLayer_profiler_layer/profiler/profiler_query_pool.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "profiler_memory_manager.h"
+#include "profiler_helpers.h"
 
 #include <vulkan/vk_layer.h>
 
@@ -41,7 +42,7 @@ namespace Profiler
         void ResolveQueryDataGpu( VkCommandBuffer, uint32_t );
         void ResolveQueryDataCpu( uint32_t );
 
-        __forceinline uint64_t GetQueryData( uint32_t queryIndex ) const
+        PROFILER_FORCE_INLINE uint64_t GetQueryData( uint32_t queryIndex ) const
         {
             return reinterpret_cast<const uint64_t*>( m_QueryResultsBufferAllocation.m_pMappedMemory )[ queryIndex ];
         }

--- a/VkLayer_profiler_layer/profiler/profiler_sync.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_sync.cpp
@@ -254,6 +254,10 @@ namespace Profiler
     \***********************************************************************************/
     void DeviceProfilerSynchronization::SendSynchronizationTimestamps()
     {
+        // For some reason this code causes hangs on Ubuntu with nvidia-driver-510.
+        // Validation layer doesn't report any issues, so it may be a driver bug.
+        // TODO: Check other drivers/gpus.
+#if !defined( __linux__ )
         assert( m_pDevice );
 
         // Reset query pool
@@ -282,6 +286,7 @@ namespace Profiler
         }
 
         m_SynchronizationTimestampsSent = true;
+#endif
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler_layer_objects/VkObject.h
+++ b/VkLayer_profiler_layer/profiler_layer_objects/VkObject.h
@@ -38,7 +38,8 @@ namespace Profiler
 
         inline static constexpr VkObjectT GetObjectHandleAsVulkanHandle( uint64_t object )
         {
-            return *reinterpret_cast<VkObjectT*>(&static_cast<uintptr_t>(object));
+            uintptr_t uintptrObj = static_cast<uintptr_t>(object);
+            return *reinterpret_cast<VkObjectT*>(&uintptrObj);
         }
     };
 
@@ -69,8 +70,9 @@ namespace Profiler
     template<typename VkObjectT>
     struct VkObject_Traits : VkObject_Traits_Base<VkObjectT, std::is_pointer_v<VkObjectT>>
     {
-        using VkObject_Traits_Base::GetObjectHandleAsUint64;
-        using VkObject_Traits_Base::GetObjectHandleAsVulkanHandle;
+        using Base = VkObject_Traits_Base<VkObjectT, std::is_pointer_v<VkObjectT>>;
+        using Base::GetObjectHandleAsUint64;
+        using Base::GetObjectHandleAsVulkanHandle;
         static constexpr VkObjectType ObjectType                            = VK_OBJECT_TYPE_UNKNOWN;
         static constexpr VkDebugReportObjectTypeEXT DebugReportObjectType   = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
         static constexpr const char ObjectTypeName[]                        = "Unknown object type";
@@ -79,8 +81,9 @@ namespace Profiler
     
     #define VK_OBJECT_FN( TYPE, OBJECT_TYPE, DEBUG_REPORT_OBJECT_TYPE, SHOULD_HAVE_DEBUG_NAME )         \
     template<> struct VkObject_Traits<TYPE> : VkObject_Traits_Base<TYPE, std::is_pointer_v<TYPE>> {     \
-        using VkObject_Traits_Base::GetObjectHandleAsUint64;                                            \
-        using VkObject_Traits_Base::GetObjectHandleAsVulkanHandle;                                      \
+        using Base = VkObject_Traits_Base<TYPE, std::is_pointer_v<TYPE>>;                               \
+        using Base::GetObjectHandleAsUint64;                                                            \
+        using Base::GetObjectHandleAsVulkanHandle;                                                      \
         static constexpr VkObjectType ObjectType                            = OBJECT_TYPE;              \
         static constexpr VkDebugReportObjectTypeEXT DebugReportObjectType   = DEBUG_REPORT_OBJECT_TYPE; \
         static constexpr const char ObjectTypeName[]                        = #TYPE;                    \

--- a/VkLayer_profiler_layer/profiler_overlay/CMakeLists.txt
+++ b/VkLayer_profiler_layer/profiler_overlay/CMakeLists.txt
@@ -94,6 +94,9 @@ add_library (profiler_overlay
     ${imgui_platform}
     ${imgui_widgets})
 
+target_link_libraries (profiler_overlay
+    profiler_helpers)
+
 # Set include path
 target_include_directories (profiler_overlay
     PRIVATE ${VULKAN_HEADERS_INCLUDE_DIR}

--- a/VkLayer_profiler_layer/profiler_overlay/imgui_impl_xcb.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/imgui_impl_xcb.cpp
@@ -40,7 +40,7 @@ ImGui_ImplXcb_Context::ImGui_ImplXcb_Context( xcb_window_t window )
 {
     // Connect to X server
     m_Connection = xcb_connect( nullptr, nullptr );
-    if( !m_Connection )
+    if( xcb_connection_has_error( m_Connection ) )
         InitError();
 
     m_InputWindow = xcb_generate_id( m_Connection );

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -2665,4 +2665,32 @@ namespace Profiler
 
         ImGui::TextUnformatted( pName );
     }
+
+    /***********************************************************************************\
+
+    Function:
+        PrintDuration
+
+    Description:
+
+    \***********************************************************************************/
+    template <typename Data>
+    void ProfilerOverlayOutput::PrintDuration( const Data& data )
+    {
+        if( ( data.m_BeginTimestamp != UINT64_MAX ) && ( data.m_EndTimestamp != UINT64_MAX ) )
+        {
+            const uint64_t ticks = data.m_EndTimestamp - data.m_BeginTimestamp;
+
+            // Print the duration
+            ImGuiX::TextAlignRight( "%.2f %s",
+                m_TimestampDisplayUnit * ticks * m_TimestampPeriod.count(),
+                m_pTimestampDisplayUnitStr );
+        }
+        else
+        {
+            // No data collected in this mode
+            ImGuiX::TextAlignRight( "- %s",
+                m_pTimestampDisplayUnitStr );
+        }
+    }
 }

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
@@ -228,24 +228,7 @@ namespace Profiler
         void DrawShaderCapabilityBadge( uint32_t color, const char* shortName, const char* longName );
 
         template<typename Data>
-        void PrintDuration( const Data& data )
-        {
-            if( (data.m_BeginTimestamp != UINT64_MAX) && (data.m_EndTimestamp != UINT64_MAX) )
-            {
-                const uint64_t ticks = data.m_EndTimestamp - data.m_BeginTimestamp;
-
-                // Print the duration
-                ImGuiX::TextAlignRight( "%.2f %s",
-                    m_TimestampDisplayUnit * ticks * m_TimestampPeriod.count(),
-                    m_pTimestampDisplayUnitStr );
-            }
-            else
-            {
-                // No data collected in this mode
-                ImGuiX::TextAlignRight( "- %s",
-                    m_pTimestampDisplayUnitStr );
-            }
-        }
+        void PrintDuration( const Data& data );
 
         // Sort frame browser data
         template<typename Data>

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
@@ -181,6 +181,14 @@ namespace Profiler
             if( submitBatchData.m_Handle == queue )
             {
                 m_CpuQueueSubmitTimestampOffset = GetNormalizedCpuTimestamp( submitBatchData.m_Timestamp );
+
+                // Use first submitted packet's begin timestamp as a reference if synchronization timestamps were not sent.
+                if( m_GpuQueueSubmitTimestampOffset == 0 )
+                {
+                    m_GpuQueueSubmitTimestampOffset = !submitBatchData.m_Submits.empty()
+                        ? submitBatchData.m_Submits.front().m_BeginTimestamp
+                        : 0;
+                }
                 break;
             }
         }

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.h
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.h
@@ -22,6 +22,7 @@
 #include "profiler_helpers/profiler_time_helpers.h"
 #include <vulkan/vulkan.h>
 #include <filesystem>
+#include <vector>
 
 namespace Profiler
 {

--- a/VkLayer_profiler_layer/utils/lockable_unordered_map.h
+++ b/VkLayer_profiler_layer/utils/lockable_unordered_map.h
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 #pragma once
+#include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
 


### PR DESCRIPTION
Add missing includes and wrap compiler extensions with macros.
Fix linking error on Linux when the profiled application uses ImGui.
Fix hangs on nvidia by temporarily disabling synchronization timestamps at the beginning of frame.
Use xcb_connection_has_error instead of checking m_Connection (which is always non-null).