### PR TITLE
Fix crashes on Swapchain recreation

### DIFF
--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -372,6 +372,8 @@ namespace Profiler
 
         m_ImageViews.clear();
 
+        m_Images.clear();
+
         for( auto& fence : m_CommandFences )
         {
             m_pDevice->Callbacks.DestroyFence( m_pDevice->Handle, fence, nullptr );
@@ -386,8 +388,11 @@ namespace Profiler
 
         m_CommandSemaphores.clear();
 
+        m_ImageFormat = VK_FORMAT_UNDEFINED;
+
         m_Window = OSWindowHandle();
         m_pDevice = nullptr;
+        m_pSwapchain = nullptr;
     }
 
     /***********************************************************************************\


### PR DESCRIPTION
Destroying a swapchain and creating a new one would simply cause a ton of dangling pointers and crashes.

Simply doing:

```cpp
vkCreateSwapchainKHR( ... );
vkGetSwapchainImagesKHR( ... );

render();

vkDestroySwapchainKHR( ... );

vkCreateSwapchainKHR( ... );
```

would trigger it.


This PR fixes it.

TBH the code follows some bad patterns, for example:

```cpp
if( (result == VK_SUCCESS) && (pCreateInfo->imageFormat != m_ImageFormat) )
{
	if( m_RenderPass != VK_NULL_HANDLE )
	{
	    // Destroy old render pass
	    m_pDevice->Callbacks.DestroyRenderPass( m_pDevice->Handle, m_RenderPass, nullptr );
	}
	...
}
```

Will never create `m_RenderPass` if it finds `pCreateInfo->imageFormat == m_ImageFormat`; even though `m_RenderPass` could be a null handle.

This PR doesn't address those issues, but it fixes what I needed to get Godot working with this layer.

Cheers.