### PR TITLE
Rename the layer to match spec naming requirements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,5 +35,17 @@ include (CMake/platform.cmake)
 # Build third-party dependencies.
 add_subdirectory (External EXCLUDE_FROM_ALL)
 
+find_package (Python3 REQUIRED)
+string (CONFIGURE [[
+    execute_process (COMMAND ${Python3_EXECUTABLE}
+        "${CMAKE_CURRENT_LIST_DIR}/VkLayer_profiler_layer/scripts/gen_licenses.py"
+        --license "Vulkan(R) Profiling Layer" "${CMAKE_CURRENT_LIST_DIR}/LICENSE.md"
+        --externaldir "${CMAKE_CURRENT_LIST_DIR}/External"
+        --output "${CMAKE_BINARY_DIR}/LICENSES")
+    ]] PROFILER_GENERATE_LICENSES_CODE)
+
+install (CODE ${PROFILER_GENERATE_LICENSES_CODE})
+install (FILES "${CMAKE_BINARY_DIR}/LICENSES" DESTINATION .)
+
 # Include sub-projects
 add_subdirectory (VkLayer_profiler_layer)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ On Windows, install [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/).
 On Linux (Debian-based systems), install libvulkan-dev and glslang-tools packages.
 
 ## Usage
-To enable the layer add `"VK_LAYER_profiler"` to the layer list in VkInstanceCreateInfo or to the VK_INSTANCE_LAYERS environment variable. The later method allows to profile applications without the need to modify the source code and is recommended for manual analysis.
+To enable the layer add `"VK_LAYER_PROFILER_unified"` to the layer list in VkInstanceCreateInfo or to the VK_INSTANCE_LAYERS environment variable. The later method allows to profile applications without the need to modify the source code and is recommended for manual analysis.
 
 ### Configuration
 The layer can be configured to handle more specific use cases. The following table describes the options available to the user.

--- a/VkLayer_profiler_layer/CMakeLists.txt
+++ b/VkLayer_profiler_layer/CMakeLists.txt
@@ -27,7 +27,8 @@ set (PROFILER_LAYER_VER_MINOR 0)
 set (PROFILER_LAYER_VER_BUILD 9999)
 set (PROFILER_LAYER_VER_PATCH 0)
 set (PROFILER_LAYER_VER_IMPLEMENTATION 1)
-set (PROFILER_LAYER_NAME VK_LAYER_profiler)
+set (PROFILER_LAYER_NAME VK_LAYER_PROFILER_unified)
+set (PROFILER_LAYER_API_VERSION "1.1.106")
 set (PROFILER_LAYER_PROJECTNAME VkLayer_profiler_layer)
 set (PROFILER_LAYER_COMPANYNAME )
 set (PROFILER_LAYER_FILEDESCRIPTION "Simple Vulkan(R) Profiling Layer")
@@ -43,8 +44,31 @@ if (PROFILER_GEN_VERSION_INFO_RESULT STREQUAL "0")
     include ("${CMAKE_BINARY_DIR}/profiler_version.cmake")
 endif ()
 
+# Get Vulkan headers version
+function (get_vulkan_api_version)
+    set (vulkan_ver_major 1)
+    set (vulkan_ver_minor 1)
+    set (vulkan_ver_headers 106)
+
+    set (vulkan_core_path "${VULKAN_HEADERS_INSTALL_DIR}/include/vulkan/vulkan_core.h")
+    if (EXISTS ${vulkan_core_path})
+        file (READ ${vulkan_core_path} ver)
+        if (ver MATCHES "#define[ ]+VK_HEADER_VERSION_COMPLETE[ ]+VK_MAKE_API_VERSION\\([ ]*[0-9]+,[ ]*([0-9]+),[ ]*([0-9]+),[ ]*VK_HEADER_VERSION[ ]*\\)")
+            set (vulkan_ver_major ${CMAKE_MATCH_1})
+            set (vulkan_ver_minor ${CMAKE_MATCH_2})
+        endif ()
+        if (ver MATCHES "#define[ ]+VK_HEADER_VERSION[ ]+([0-9]+)")
+            set (vulkan_ver_headers ${CMAKE_MATCH_1})
+        endif ()
+    endif ()
+
+    set (PROFILER_LAYER_API_VERSION "${vulkan_ver_major}.${vulkan_ver_minor}.${vulkan_ver_headers}" PARENT_SCOPE)
+endfunction ()
+get_vulkan_api_version ()
+
 project (${PROFILER_LAYER_PROJECTNAME})
 message ("-- Profiler version: ${PROFILER_LAYER_VER_MAJOR}.${PROFILER_LAYER_VER_MINOR}.${PROFILER_LAYER_VER_BUILD}.${PROFILER_LAYER_VER_PATCH}")
+message ("-- Vulkan version: ${PROFILER_LAYER_API_VERSION}")
 
 # Generate dispatch tables
 add_custom_command (

--- a/VkLayer_profiler_layer/VkLayer_profiler_layer.json.in
+++ b/VkLayer_profiler_layer/VkLayer_profiler_layer.json.in
@@ -1,10 +1,10 @@
 {
     "file_format_version": "1.0.0",
     "layer": {
-        "name": "VK_LAYER_profiler",
+        "name": "@PROFILER_LAYER_NAME@",
         "type": "GLOBAL",
         "library_path": "@THIS_DIR@$<TARGET_FILE_NAME:@PROFILER_LAYER_PROJECTNAME@>",
-        "api_version": "1.1.106",
+        "api_version": "@PROFILER_LAYER_API_VERSION@",
         "implementation_version": "@PROFILER_LAYER_VER_BUILD@",
         "description": "@PROFILER_LAYER_FILEDESCRIPTION@",
         "instance_extensions": [

--- a/VkLayer_profiler_layer/scripts/gen_licenses.py
+++ b/VkLayer_profiler_layer/scripts/gen_licenses.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2024 Lukasz Stalmirski
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+import os
+import pathlib
+import argparse
+
+# List of file names (without extension) to scan for licenses.
+LICENSE_FILES = [ "COPYING", "LICENSE" ]
+
+def find_licenses( directory ):
+    licenses = {}
+    for lib in os.listdir( directory ):
+        libdir = os.path.join( directory, lib )
+        if not os.path.isdir( libdir ):
+            continue
+        for file in os.listdir( libdir ):
+            path = os.path.join( libdir, file )
+            if not os.path.isfile( path ):
+                continue
+            filename = pathlib.Path( path ).stem
+            if not filename in LICENSE_FILES:
+                continue
+            licenses[ lib ] = path
+            break
+        if lib not in licenses.keys():
+            raise Exception( f"License not found for {lib}" )
+    return licenses
+
+def append_license_file( out, name, path ):
+    out.write( f"[{name}]\n" )
+    with open( path ) as license_file:
+        out.write( license_file.read() )
+    out.write( "\n" )
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument( "--license", action="append", nargs=2, dest="license_paths", metavar=("NAME", "PATH") )
+    parser.add_argument( "--externaldir", action="append", dest="external_dirs" )
+    parser.add_argument( "--output", "-o", dest="output", required=True )
+    args = parser.parse_args()
+
+    with open( args.output, mode="w" ) as out:
+        for lib, path in args.license_paths:
+            append_license_file( out, lib, path )
+        for directory in args.external_dirs:
+            licenses = find_licenses( directory )
+            for lib, path in licenses.items():
+                append_license_file( out, lib, path )
+
+    print( f"-- Licenses written to {args.output}" )


### PR DESCRIPTION
Rename layer to "VK_LAYER_PROFILER_unified" so that the layer can be used with Vulkan Configurator.

Additionally:
- Generate list of licenses of all used external libraries automatically on install.
- Provide version of Vulkan headers used to build the layer.
