### PR TITLE
Fix compile error with g++ 13.2.0

### DIFF
--- a/VkLayer_profiler_layer/profiler_layer_functions/Dispatch.h
+++ b/VkLayer_profiler_layer/profiler_layer_functions/Dispatch.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <map>
 #include <mutex>
+#include <memory>
 
 namespace Profiler
 {


### PR DESCRIPTION
Fixes the following compile error with g++ 13.2.0 (Ubuntu 23.10):

VulkanProfiler/VkLayer_profiler_layer/profiler_layer_functions/Dispatch.h:151:13: error: ‘hash’ is not a class template

Tests still fail to compile, but that is a separate issue.