### PR TITLE
Fix Windows keyboard input.

### DIFF
--- a/VkLayer_profiler_layer/profiler_overlay/imgui_impl_win32.h
+++ b/VkLayer_profiler_layer/profiler_overlay/imgui_impl_win32.h
@@ -39,7 +39,7 @@ public:
 
 private:
     HWND m_AppWindow;
-    HHOOK m_GetMessageHook;
+    DWORD m_AppWindowThreadId;
     ImGuiContext* m_pImGuiContext;
     int m_RawMouseX;
     int m_RawMouseY;


### PR DESCRIPTION
Translate WM_KEYDOWN to WM_CHAR for keyboard input to work again.
Hook each window thread once to avoid receiving the same message multiple times if multiple windows are handled by the same thread.