### PR TITLE
Refactor VkShaderModule internal data structure.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -147,7 +147,7 @@ namespace Profiler
         ConcurrentMap<VkCommandBuffer, std::unique_ptr<ProfilerCommandBuffer>> m_pCommandBuffers;
         ConcurrentMap<VkCommandPool, std::unique_ptr<DeviceProfilerCommandPool>> m_pCommandPools;
 
-        ConcurrentMap<VkShaderModule, ProfilerShaderModule> m_ShaderModules;
+        ConcurrentMap<VkShaderModule, std::shared_ptr<ProfilerShaderModule>> m_pShaderModules;
         ConcurrentMap<VkPipeline, DeviceProfilerPipeline> m_Pipelines;
 
         ConcurrentMap<VkDeferredOperationKHR, DeferredOperationCallback> m_DeferredOperationCallbacks;
@@ -170,7 +170,7 @@ namespace Profiler
         void ReleasePerformanceConfigurationINTEL();
 
         void CreateInternalPipeline( DeviceProfilerPipelineType, const char* );
-        
+
         void SetPipelineShaderProperties( DeviceProfilerPipeline& pipeline, uint32_t stageCount, const VkPipelineShaderStageCreateInfo* pStages );
         void SetDefaultObjectName( const DeviceProfilerPipeline& pipeline );
 

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -709,16 +709,8 @@ namespace Profiler
         Contains data collected per-pipeline.
 
     \***********************************************************************************/
-    struct DeviceProfilerPipelineData
+    struct DeviceProfilerPipelineData : DeviceProfilerPipeline
     {
-        VkPipeline                                          m_Handle = {};
-        VkPipelineBindPoint                                 m_BindPoint = {};
-        ProfilerShaderTuple                                 m_ShaderTuple = {};
-        DeviceProfilerPipelineType                          m_Type = {};
-
-        bool                                                m_UsesRayQuery = false;
-        bool                                                m_UsesRayTracing = false;
-
         DeviceProfilerTimestamp                             m_BeginTimestamp;
         DeviceProfilerTimestamp                             m_EndTimestamp;
         ContainerType<struct DeviceProfilerDrawcall>        m_Drawcalls = {};
@@ -726,12 +718,7 @@ namespace Profiler
         inline DeviceProfilerPipelineData() = default;
 
         inline DeviceProfilerPipelineData( const DeviceProfilerPipeline& pipeline )
-            : m_Handle( pipeline.m_Handle )
-            , m_BindPoint( pipeline.m_BindPoint )
-            , m_ShaderTuple( pipeline.m_ShaderTuple )
-            , m_Type( pipeline.m_Type )
-            , m_UsesRayQuery( pipeline.m_UsesRayQuery )
-            , m_UsesRayTracing( pipeline.m_UsesRayTracing )
+            : DeviceProfilerPipeline( pipeline )
         {
         }
 

--- a/VkLayer_profiler_layer/profiler/profiler_shader.h
+++ b/VkLayer_profiler_layer/profiler/profiler_shader.h
@@ -20,18 +20,36 @@
 
 #pragma once
 #include "profiler_helpers.h"
+#include <algorithm>
 #include <array>
+#include <vector>
 #include <stdint.h>
 #include <vulkan/vulkan.h>
 #include <spirv/unified1/spirv.h>
 
 namespace Profiler
 {
+    struct ProfilerShaderModule
+    {
+        uint32_t m_Hash = 0;
+        std::vector<uint32_t> m_Bytecode = {};
+        std::vector<SpvCapability> m_Capabilities = {};
+    };
+
+    struct ProfilerShader
+    {
+        uint32_t m_Hash = 0;
+        uint32_t m_Index = 0;
+        VkShaderStageFlagBits m_Stage = {};
+        std::string m_EntryPoint = {};
+        std::shared_ptr<ProfilerShaderModule> m_pShaderModule = nullptr;
+    };
+
     struct ProfilerShaderTuple
     {
         uint32_t m_Hash = 0;
 
-        BitsetArray<VkShaderStageFlagBits, uint32_t, 32> m_Stages = {};
+        std::vector<ProfilerShader> m_Shaders = {};
 
         inline constexpr bool operator==( const ProfilerShaderTuple& rh ) const
         {
@@ -42,12 +60,32 @@ namespace Profiler
         {
             return !operator==( rh );
         }
-    };
 
-    struct ProfilerShaderModule
-    {
-        uint32_t                   m_Hash = 0;
-        std::vector<SpvCapability> m_Capabilities = {};
+        inline const ProfilerShader* GetFirstShaderAtStage( VkShaderStageFlagBits stage ) const
+        {
+            const size_t stageCount = m_Shaders.size();
+            for( size_t i = 0; i < stageCount; ++i )
+            {
+                if( m_Shaders[ i ].m_Stage == stage )
+                {
+                    return &m_Shaders[ i ];
+                }
+            }
+            return nullptr;
+        }
+
+        inline const ProfilerShader* GetShaderAtIndex( uint32_t index ) const
+        {
+            const size_t stageCount = m_Shaders.size();
+            for( size_t i = 0; i < stageCount; ++i )
+            {
+                if( m_Shaders[ i ].m_Index == index )
+                {
+                    return &m_Shaders[ i ];
+                }
+            }
+            return nullptr;
+        }
     };
 }
 


### PR DESCRIPTION
- Use shared pointers to keep references to VkShaderModules in VkPipelines valid.
- Save shader module's bytecode for future features.
- Allow casting from DeviceProfilerPipelineData back to DeviceProfilerPipeline.