### PR TITLE
Add VK_KHR_pipeline_executable_properties support.

### DIFF
--- a/VkLayer_profiler_layer/CMakeLists.txt
+++ b/VkLayer_profiler_layer/CMakeLists.txt
@@ -192,6 +192,7 @@ set (extension_functions
     "profiler_layer_functions/extensions/VkDrawIndirectCountKhr_functions.h"
     "profiler_layer_functions/extensions/VkDynamicRenderingKhr_functions.cpp"
     "profiler_layer_functions/extensions/VkDynamicRenderingKhr_functions.h"
+    "profiler_layer_functions/extensions/VkPipelineExecutablePropertiesKhr_functions.h"
     "profiler_layer_functions/extensions/VkRayTracingPipelineKhr_functions.cpp"
     "profiler_layer_functions/extensions/VkRayTracingPipelineKhr_functions.h"
     "profiler_layer_functions/extensions/VkSurfaceKhr_functions.cpp"

--- a/VkLayer_profiler_layer/VkLayer_profiler_layer.json.in
+++ b/VkLayer_profiler_layer/VkLayer_profiler_layer.json.in
@@ -75,7 +75,7 @@
                     "description": "Capture VkPipeline's executable properties and internal shader representations for more detailed insights into the shaders executed on the GPU.",
                     "env": "VKPROF_enable_pipeline_executable_properties_ext",
                     "type": "BOOL",
-                    "default": true
+                    "default": false
                 },
                 {
                     "key": "enable_render_pass_begin_end_profiling",

--- a/VkLayer_profiler_layer/VkLayer_profiler_layer.json.in
+++ b/VkLayer_profiler_layer/VkLayer_profiler_layer.json.in
@@ -70,6 +70,14 @@
                     "default": true
                 },
                 {
+                    "key": "enable_pipeline_executable_properties_ext",
+                    "label": "Enable pipeline executable properties extension",
+                    "description": "Capture VkPipeline's executable properties and internal shader representations for more detailed insights into the shaders executed on the GPU.",
+                    "env": "VKPROF_enable_pipeline_executable_properties_ext",
+                    "type": "BOOL",
+                    "default": true
+                },
+                {
                     "key": "enable_render_pass_begin_end_profiling",
                     "label": "Enable VkRenderPass begin and end profiling",
                     "description": "Insert timestamp queries before and after vkCmdBeginRenderPass and vkCmdEndRenderPass when sampling mode is at most per render pass.",

--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -83,6 +83,8 @@ namespace Profiler
         DeviceProfilerPipeline& GetPipeline( VkPipeline pipeline );
         DeviceProfilerRenderPass& GetRenderPass( VkRenderPass renderPass );
 
+        bool ShouldCapturePipelineExecutableProperties() const;
+
         void CreateCommandPool( VkCommandPool, const VkCommandPoolCreateInfo* );
         void DestroyCommandPool( VkCommandPool );
 
@@ -161,6 +163,10 @@ namespace Profiler
         ProfilerMetricsApi_INTEL m_MetricsApiINTEL;
 
         DeviceProfilerSynchronization m_Synchronization;
+
+        // Whether VK_KHR_pipeline_executable_properties is available for the profiled device.
+        // In such case the internal representations of pipelines may be inspected to give more insight on potential performance issues.
+        bool                    m_PipelineExecutablePropertiesEnabled;
 
         void*                   m_pStablePowerStateHandle;
 

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.cpp
@@ -271,6 +271,11 @@ namespace Profiler
     {
         auto& dd = DeviceDispatch.Get( device );
 
+        // Capture executable properties for shader inspection.
+        VkGraphicsPipelineCreateInfo* pCreateInfosWithExecutableProperties = nullptr;
+        VkPipelineExecutablePropertiesKhr_Functions::CapturePipelineExecutableProperties(
+            dd, createInfoCount, &pCreateInfos, &pCreateInfosWithExecutableProperties );
+
         // Create the pipelines
         VkResult result = dd.Device.Callbacks.CreateGraphicsPipelines(
             device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines );
@@ -280,6 +285,8 @@ namespace Profiler
             // Register pipelines
             dd.Profiler.CreatePipelines( createInfoCount, pCreateInfos, pPipelines );
         }
+
+        free( pCreateInfosWithExecutableProperties );
 
         return result;
     }
@@ -302,6 +309,11 @@ namespace Profiler
     {
         auto& dd = DeviceDispatch.Get( device );
 
+        // Capture executable properties for shader inspection.
+        VkComputePipelineCreateInfo* pCreateInfosWithExecutableProperties = nullptr;
+        VkPipelineExecutablePropertiesKhr_Functions::CapturePipelineExecutableProperties(
+            dd, createInfoCount, &pCreateInfos, &pCreateInfosWithExecutableProperties );
+
         // Create the pipelines
         VkResult result = dd.Device.Callbacks.CreateComputePipelines(
             device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines );
@@ -311,6 +323,8 @@ namespace Profiler
             // Register pipelines
             dd.Profiler.CreatePipelines( createInfoCount, pCreateInfos, pPipelines );
         }
+
+        free( pCreateInfosWithExecutableProperties );
 
         return result;
     }

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.h
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkDevice_functions.h
@@ -29,6 +29,7 @@
 #include "VkDrawIndirectCountAmd_functions.h"
 #include "VkDrawIndirectCountKhr_functions.h"
 #include "VkDynamicRenderingKhr_functions.h"
+#include "VkPipelineExecutablePropertiesKhr_functions.h"
 #include "VkRayTracingPipelineKhr_functions.h"
 #include "VkSwapchainKhr_functions.h"
 #include "VkSynchronization2Khr_functions.h"
@@ -55,6 +56,7 @@ namespace Profiler
         , VkDrawIndirectCountAmd_Functions
         , VkDrawIndirectCountKhr_Functions
         , VkDynamicRenderingKhr_Functions
+        , VkPipelineExecutablePropertiesKhr_Functions
         , VkRayTracingPipelineKhr_Functions
         , VkSwapchainKhr_Functions
         , VkSynchronization2Khr_Functions

--- a/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkPipelineExecutablePropertiesKhr_functions.h
+++ b/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkPipelineExecutablePropertiesKhr_functions.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 Lukasz Stalmirski
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include "VkDevice_functions_base.h"
+
+namespace Profiler
+{
+    struct VkPipelineExecutablePropertiesKhr_Functions : VkDevice_Functions_Base
+    {
+        /***********************************************************************************\
+
+        Function:
+            CapturePipelineExecutableProperties
+
+        Description:
+
+        \***********************************************************************************/
+        template<typename VkPipelineCreateInfoT>
+        static void CapturePipelineExecutableProperties(
+            Dispatch& dd,
+            uint32_t createInfoCount,
+            const VkPipelineCreateInfoT** ppCreateInfos,
+            VkPipelineCreateInfoT** ppCreateInfosWithExecutableProperties )
+        {
+            if( dd.Profiler.ShouldCapturePipelineExecutableProperties() )
+            {
+                const size_t createInfoSize = createInfoCount * sizeof( VkPipelineCreateInfoT );
+
+                // To capture the properties and internal representations, flags must be passed to the ICD.
+                // Create a copy of pCreateInfos list and add these flags.
+                *ppCreateInfosWithExecutableProperties =
+                    reinterpret_cast<VkPipelineCreateInfoT*>(malloc( createInfoSize ));
+
+                if( *ppCreateInfosWithExecutableProperties != nullptr )
+                {
+                    memcpy( *ppCreateInfosWithExecutableProperties, *ppCreateInfos, createInfoSize );
+
+                    for( uint32_t i = 0; i < createInfoCount; ++i )
+                    {
+                        (*ppCreateInfosWithExecutableProperties)[ i ].flags |=
+                            VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR |
+                            VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR;
+                    }
+
+                    *ppCreateInfos = *ppCreateInfosWithExecutableProperties;
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
Enable VK_KHR_pipeline_executable_properties to request additional info on the pipeline shaders from the ICD.