### PR TITLE
Use VK_EXT_calibrated_timestamps to synchronize CPU and GPU traces.

### DIFF
--- a/VkLayer_profiler_layer/profiler/CMakeLists.txt
+++ b/VkLayer_profiler_layer/profiler/CMakeLists.txt
@@ -53,8 +53,10 @@ set (sources
     "profiler_shader.cpp"
     "profiler_sync.cpp"
     # Windows
+    "profiler_counters_windows.inl"
     "profiler_helpers_windows.cpp"
     # Linux
+    "profiler_counters_linux.inl"
     "profiler_helpers_linux.cpp"
     )
 

--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -178,7 +178,9 @@ namespace Profiler
     {
         std::unordered_set<std::string> deviceExtensions = {
             VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME,
-            VK_EXT_DEBUG_MARKER_EXTENSION_NAME
+            VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
+            VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
+            VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME
         };
 
         // Load configuration that will be used by the profiler.
@@ -302,6 +304,10 @@ namespace Profiler
 
         // Initialize synchroniation manager
         DESTROYANDRETURNONFAIL( m_Synchronization.Initialize( m_pDevice ) );
+
+        VkTimeDomainEXT hostTimeDomain = m_Synchronization.GetHostTimeDomain();
+        m_CpuTimestampCounter.SetTimeDomain( hostTimeDomain );
+        m_CpuFpsCounter.SetTimeDomain( hostTimeDomain );
 
         // Initialize memory manager
         DESTROYANDRETURNONFAIL( m_MemoryManager.Initialize( m_pDevice ) );
@@ -1199,13 +1205,12 @@ namespace Profiler
         m_Data.m_CPU.m_FramesPerSec = m_CpuFpsCounter.GetValue();
         m_Data.m_CPU.m_ThreadId = ProfilerPlatformFunctions::GetCurrentThreadId();
 
-        m_CpuTimestampCounter.Begin();
-
         // Prepare aggregator for the next frame
         m_DataAggregator.Reset();
 
-        // Send synchronization timestamps
+        // Send synchronization timestamps and begin next frame
         m_Synchronization.SendSynchronizationTimestamps();
+        m_CpuTimestampCounter.Begin();
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -111,9 +111,10 @@ namespace Profiler
         void CreateRenderPass( VkRenderPass, const VkRenderPassCreateInfo2* );
         void DestroyRenderPass( VkRenderPass );
 
-        void PreSubmitCommandBuffers( VkQueue );
-        void PostSubmitCommandBuffers( VkQueue, uint32_t, const VkSubmitInfo* );
-        void PostSubmitCommandBuffers( VkQueue, uint32_t, const VkSubmitInfo2* );
+        void CreateSubmitBatchInfo( VkQueue, uint32_t, const VkSubmitInfo*, DeviceProfilerSubmitBatch* );
+        void CreateSubmitBatchInfo( VkQueue, uint32_t, const VkSubmitInfo2*, DeviceProfilerSubmitBatch* );
+        void PreSubmitCommandBuffers( const DeviceProfilerSubmitBatch& );
+        void PostSubmitCommandBuffers( const DeviceProfilerSubmitBatch& );
 
         void FinishFrame();
 
@@ -188,7 +189,7 @@ namespace Profiler
         decltype(m_pCommandBuffers)::iterator FreeCommandBuffer( decltype(m_pCommandBuffers)::iterator );
 
         template<typename SubmitInfoT>
-        void PostSubmitCommandBuffersImpl( VkQueue, uint32_t, const SubmitInfoT* );
+        void CreateSubmitBatchInfoImpl( VkQueue, uint32_t, const SubmitInfoT*, DeviceProfilerSubmitBatch* );
     };
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler_counters.h
+++ b/VkLayer_profiler_layer/profiler/profiler_counters.h
@@ -88,27 +88,28 @@ namespace Profiler
         explicit CpuTimestampCounter( VkTimeDomainEXT domain = OSGetDefaultTimeDomain() ) : m_TimeDomain( domain ) { Reset(); }
 
         // Set the time domain in which the timestamps should be collected
-        void SetTimeDomain( VkTimeDomainEXT domain ) { m_TimeDomain = domain; }
+        inline void SetTimeDomain( VkTimeDomainEXT domain ) { m_TimeDomain = domain; }
 
         // Reset counter values
-        void Reset() { m_BeginValue = m_EndValue = OSGetTimestamp( m_TimeDomain ); }
+        inline void Reset() { m_BeginValue = m_EndValue = OSGetTimestamp( m_TimeDomain ); }
 
         // Begin timestamp query
-        void Begin() { m_BeginValue = OSGetTimestamp( m_TimeDomain ); }
+        inline void Begin() { m_BeginValue = OSGetTimestamp( m_TimeDomain ); }
 
         // End timestamp query
-        void End() { m_EndValue = OSGetTimestamp( m_TimeDomain ); }
+        inline void End() { m_EndValue = OSGetTimestamp( m_TimeDomain ); }
 
         // Get time range between begin and end
         template<typename Unit = std::chrono::nanoseconds>
-        Unit GetValue() const
+        inline auto GetValue() const
         {
             return std::chrono::duration_cast<Unit>(std::chrono::nanoseconds(
                 ((m_EndValue - m_BeginValue) * 1'000'000'000) / OSGetTimestampFrequency( m_TimeDomain ) ));
         }
 
-        uint64_t GetBeginValue() const { return m_BeginValue; }
-        uint64_t GetCurrentValue() const { return OSGetTimestamp( m_TimeDomain ); }
+        inline uint64_t GetBeginValue() const { return m_BeginValue; }
+
+        inline uint64_t GetCurrentValue() const { return OSGetTimestamp( m_TimeDomain ); }
 
     protected:
         uint64_t m_BeginValue;

--- a/VkLayer_profiler_layer/profiler/profiler_counters.h
+++ b/VkLayer_profiler_layer/profiler/profiler_counters.h
@@ -175,7 +175,7 @@ namespace Profiler
         // Initialize event counter
         template<typename Unit = std::chrono::seconds>
         inline CpuEventFrequencyCounter( Unit refreshRate = std::chrono::seconds( 1 ), VkTimeDomainEXT timeDomain = OSGetDefaultTimeDomain() )
-            : m_RefreshRate( std::chrono::duration_cast<std::chrono::nanoseconds>(refreshRate).count() )
+            : m_RefreshRate( std::chrono::nanoseconds( refreshRate ).count() * 0.000'000'001f )
             , m_TimeDomain( timeDomain )
         {
             m_EventCount = 0;
@@ -195,11 +195,12 @@ namespace Profiler
             m_EventCount++;
 
             const uint64_t timestamp = OSGetTimestamp( m_TimeDomain );
-            const float delta = static_cast<float>(timestamp - m_BeginTimestamp);
+            const float delta = static_cast<float>(timestamp - m_BeginTimestamp) /
+                OSGetTimestampFrequency( m_TimeDomain );
 
             if( delta > m_RefreshRate )
             {
-                m_EventFrequency = (m_EventCount * OSGetTimestampFrequency( m_TimeDomain )) / delta;
+                m_EventFrequency = m_EventCount / delta;
                 m_LastEventCount = m_EventCount;
                 m_EventCount = 0;
                 m_BeginTimestamp = timestamp;
@@ -217,7 +218,7 @@ namespace Profiler
 
     protected:
         uint64_t m_BeginTimestamp;
-        uint64_t m_RefreshRate;
+        float m_RefreshRate;
         uint32_t m_EventCount;
         uint32_t m_LastEventCount;
         float m_EventFrequency;

--- a/VkLayer_profiler_layer/profiler/profiler_counters.h
+++ b/VkLayer_profiler_layer/profiler/profiler_counters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Lukasz Stalmirski
+// Copyright (c) 2019-2024 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,8 +19,19 @@
 // SOFTWARE.
 
 #pragma once
+#include "profiler_helpers.h"
+
+#include <vulkan/vk_layer.h>
+
 #include <atomic>
 #include <chrono>
+
+// Include OS-specific implementation of CPU counters
+#ifdef WIN32
+#include "profiler_counters_windows.inl"
+#else
+#include "profiler_counters_linux.inl"
+#endif
 
 namespace Profiler
 {
@@ -74,28 +85,35 @@ namespace Profiler
     {
     public:
         // Initialize new CPU timestamp query counter
-        inline CpuTimestampCounter() { m_BeginValue = m_EndValue = std::chrono::high_resolution_clock::now(); }
+        explicit CpuTimestampCounter( VkTimeDomainEXT domain = OSGetDefaultTimeDomain() ) : m_TimeDomain( domain ) { Reset(); }
+
+        // Set the time domain in which the timestamps should be collected
+        void SetTimeDomain( VkTimeDomainEXT domain ) { m_TimeDomain = domain; }
 
         // Reset counter values
-        inline void Reset() { m_BeginValue = m_EndValue = std::chrono::high_resolution_clock::now(); }
+        void Reset() { m_BeginValue = m_EndValue = OSGetTimestamp( m_TimeDomain ); }
 
         // Begin timestamp query
-        inline void Begin() { m_BeginValue = std::chrono::high_resolution_clock::now(); }
+        void Begin() { m_BeginValue = OSGetTimestamp( m_TimeDomain ); }
 
         // End timestamp query
-        inline void End() { m_EndValue = std::chrono::high_resolution_clock::now(); }
+        void End() { m_EndValue = OSGetTimestamp( m_TimeDomain ); }
 
         // Get time range between begin and end
-        template<typename Unit>
-        inline auto GetValue() const { return std::chrono::duration_cast<Unit>(m_EndValue - m_BeginValue); }
+        template<typename Unit = std::chrono::nanoseconds>
+        Unit GetValue() const
+        {
+            return std::chrono::duration_cast<Unit>(std::chrono::nanoseconds(
+                ((m_EndValue - m_BeginValue) * 1'000'000'000) / OSGetTimestampFrequency( m_TimeDomain ) ));
+        }
 
-        inline auto GetBeginValue() const { return m_BeginValue; }
-
-        inline auto GetCurrentValue() const { return std::chrono::high_resolution_clock::now(); }
+        uint64_t GetBeginValue() const { return m_BeginValue; }
+        uint64_t GetCurrentValue() const { return OSGetTimestamp( m_TimeDomain ); }
 
     protected:
-        std::chrono::high_resolution_clock::time_point m_BeginValue;
-        std::chrono::high_resolution_clock::time_point m_EndValue;
+        uint64_t m_BeginValue;
+        uint64_t m_EndValue;
+        VkTimeDomainEXT m_TimeDomain;
     };
 
     /***********************************************************************************\
@@ -152,18 +170,22 @@ namespace Profiler
     \***********************************************************************************/
     class CpuEventFrequencyCounter
     {
-        using TimePointType = typename std::chrono::high_resolution_clock::time_point;
-        using DurationType = typename TimePointType::duration;
-
     public:
         // Initialize event counter
         template<typename Unit = std::chrono::seconds>
-        inline CpuEventFrequencyCounter( Unit refreshRate = std::chrono::seconds( 1 ) )
-            : m_RefreshRate( std::chrono::duration_cast<DurationType>(refreshRate) )
+        inline CpuEventFrequencyCounter( Unit refreshRate = std::chrono::seconds( 1 ), VkTimeDomainEXT timeDomain = OSGetDefaultTimeDomain() )
+            : m_RefreshRate( std::chrono::duration_cast<std::chrono::nanoseconds>(refreshRate).count() )
+            , m_TimeDomain( timeDomain )
         {
             m_EventCount = 0;
             m_EventFrequency = 0;
-            m_BeginTimestamp = std::chrono::high_resolution_clock::now();
+            m_BeginTimestamp = OSGetTimestamp( m_TimeDomain );
+        }
+
+        // Set the new time domain
+        inline void SetTimeDomain( VkTimeDomainEXT timeDomain )
+        {
+            m_TimeDomain = timeDomain;
         }
 
         // Update event counter
@@ -171,12 +193,12 @@ namespace Profiler
         {
             m_EventCount++;
 
-            const TimePointType timestamp = std::chrono::high_resolution_clock::now();
-            const DurationType delta = (timestamp - m_BeginTimestamp);
+            const uint64_t timestamp = OSGetTimestamp( m_TimeDomain );
+            const float delta = static_cast<float>(timestamp - m_BeginTimestamp);
 
             if( delta > m_RefreshRate )
             {
-                m_EventFrequency = (m_EventCount) / (delta.count() * REFRESH_RATE_TO_SEC);
+                m_EventFrequency = (m_EventCount * OSGetTimestampFrequency( m_TimeDomain )) / delta;
                 m_LastEventCount = m_EventCount;
                 m_EventCount = 0;
                 m_BeginTimestamp = timestamp;
@@ -193,14 +215,11 @@ namespace Profiler
         inline uint32_t GetEventCount() const { return m_LastEventCount; }
 
     protected:
-        TimePointType m_BeginTimestamp;
-        const DurationType m_RefreshRate;
+        uint64_t m_BeginTimestamp;
+        uint64_t m_RefreshRate;
         uint32_t m_EventCount;
         uint32_t m_LastEventCount;
         float m_EventFrequency;
-
-        static constexpr float REFRESH_RATE_TO_SEC =
-            static_cast<float>(DurationType::period::num) /
-            static_cast<float>(DurationType::period::den);
+        VkTimeDomainEXT m_TimeDomain;
     };
 }

--- a/VkLayer_profiler_layer/profiler/profiler_counters_linux.inl
+++ b/VkLayer_profiler_layer/profiler/profiler_counters_linux.inl
@@ -1,0 +1,112 @@
+// Copyright (c) 2024 Lukasz Stalmirski
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <time.h>
+#include <assert.h>
+
+namespace Profiler
+{
+    /***********************************************************************************\
+
+    Function:
+        OSGetPreferredTimeDomain
+
+    Description:
+        Returns the preferred time domain on this operating system.
+
+    \***********************************************************************************/
+    PROFILER_FORCE_INLINE VkTimeDomainEXT OSGetPreferredTimeDomain( uint32_t timeDomainCount, const VkTimeDomainEXT* pTimeDomains )
+    {
+        if( timeDomainCount > 0 )
+        {
+            // Check if raw monotonic clock is supported.
+            struct timespec tp;
+            if( clock_gettime( CLOCK_MONOTONIC_RAW, &tp ) == 0 )
+            {
+                for( uint32_t i = 0; i < timeDomainCount; ++i )
+                {
+                    if( pTimeDomains[ i ] == VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT )
+                    {
+                        return VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT;
+                    }
+                }
+            }
+        }
+
+        return VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        OSGetDefaultTimeDomain
+
+    Description:
+        Returns the default time domain on this operating system.
+
+    \***********************************************************************************/
+    PROFILER_FORCE_INLINE VkTimeDomainEXT OSGetDefaultTimeDomain()
+    {
+        return OSGetPreferredTimeDomain( 0, nullptr );
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        OSGetTimestamp
+
+    Description:
+        Returns current CPU timestamp.
+
+    \***********************************************************************************/
+    PROFILER_FORCE_INLINE uint64_t OSGetTimestamp( VkTimeDomainEXT timeDomain )
+    {
+        assert( (timeDomain == VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT) ||
+            (timeDomain == VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT) );
+
+        clockid_t clkid = (timeDomain == VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT)
+            ? CLOCK_MONOTONIC
+            : CLOCK_MONOTONIC_RAW;
+
+        struct timespec tp;
+        if( clock_gettime( clkid, &tp ) == 0 )
+        {
+            // Convert tp to nanoseconds.
+            return (static_cast<uint64_t>(tp.tv_sec) * 1'000'000'000) + tp.tv_nsec;
+        }
+
+        return 0;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        OSGetTimestampFrequency
+
+    Description:
+        Returns CPU counter frequency.
+
+    \***********************************************************************************/
+    PROFILER_FORCE_INLINE uint64_t OSGetTimestampFrequency( VkTimeDomainEXT timeDomain )
+    {
+        // All timestamps are already premultiplied to nanoseconds, so the frequency is 1GHz.
+        return 1'000'000'000;
+    }
+}

--- a/VkLayer_profiler_layer/profiler/profiler_counters_windows.inl
+++ b/VkLayer_profiler_layer/profiler/profiler_counters_windows.inl
@@ -1,0 +1,105 @@
+// Copyright (c) 2024 Lukasz Stalmirski
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <Windows.h>
+#include <assert.h>
+
+namespace Profiler
+{
+    /***********************************************************************************\
+
+    Function:
+        OSGetPreferredTimeDomain
+
+    Description:
+        Returns the preferred time domain on this operating system.
+
+    \***********************************************************************************/
+    PROFILER_FORCE_INLINE VkTimeDomainEXT OSGetPreferredTimeDomain( uint32_t, const VkTimeDomainEXT* )
+    {
+        return VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        OSGetDefaultTimeDomain
+
+    Description:
+        Returns the default time domain on this operating system.
+
+    \***********************************************************************************/
+    PROFILER_FORCE_INLINE VkTimeDomainEXT OSGetDefaultTimeDomain()
+    {
+        return VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        OSGetTimestamp
+
+    Description:
+        Returns current CPU timestamp.
+
+    \***********************************************************************************/
+    PROFILER_FORCE_INLINE uint64_t OSGetTimestamp( VkTimeDomainEXT timeDomain )
+    {
+        // Only performance counter time domain is supported on Windows.
+        assert( timeDomain == VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT );
+        UNREFERENCED_PARAMETER( timeDomain );
+
+        LARGE_INTEGER timestamp;
+
+        // It is very unlikely this function will ever fail.
+        // According to MSDN, it always returns a valid timestamp since Windows XP.
+        QueryPerformanceCounter( &timestamp );
+
+        return timestamp.QuadPart;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        OSGetTimestampFrequency
+
+    Description:
+        Returns CPU counter frequency.
+
+    \***********************************************************************************/
+    PROFILER_FORCE_INLINE uint64_t OSGetTimestampFrequency( VkTimeDomainEXT timeDomain )
+    {
+        // Only performance counter time domain is supported on Windows.
+        assert( timeDomain == VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT );
+        UNREFERENCED_PARAMETER( timeDomain );
+
+        // Timestamp frequency is constant and can be cached.
+        static LARGE_INTEGER frequency;
+
+        if( frequency.QuadPart == 0 )
+        {
+            // It is very unlikely this function will ever fail.
+            // According to MSDN, it always returns a valid frequency since Windows XP.
+            QueryPerformanceFrequency( &frequency );
+        }
+
+        return frequency.QuadPart;
+    }
+}

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Lukasz Stalmirski
+// Copyright (c) 2019-2024 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1183,7 +1183,7 @@ namespace Profiler
     {
         VkQueue                                             m_Handle = {};
         ContainerType<struct DeviceProfilerSubmitData>      m_Submits = {};
-        std::chrono::high_resolution_clock::time_point      m_Timestamp = {};
+        uint64_t                                            m_Timestamp = {};
         uint32_t                                            m_ThreadId = {};
     };
 
@@ -1242,10 +1242,25 @@ namespace Profiler
     \***********************************************************************************/
     struct DeviceProfilerCPUData
     {
-        std::chrono::high_resolution_clock::time_point      m_BeginTimestamp = {};
-        std::chrono::high_resolution_clock::time_point      m_EndTimestamp = {};
+        uint64_t                                            m_BeginTimestamp = {};
+        uint64_t                                            m_EndTimestamp = {};
         float                                               m_FramesPerSec = {};
         uint32_t                                            m_ThreadId = {};
+    };
+
+    /***********************************************************************************\
+
+    Structure:
+        DeviceProfilerSynchronizationTimestamps
+
+    Description:
+
+    \***********************************************************************************/
+    struct DeviceProfilerSynchronizationTimestamps
+    {
+        VkTimeDomainEXT                                     m_HostTimeDomain = {};
+        uint64_t                                            m_HostCalibratedTimestamp = {};
+        uint64_t                                            m_DeviceCalibratedTimestamp = {};
     };
 
     /***********************************************************************************\
@@ -1270,7 +1285,7 @@ namespace Profiler
 
         std::vector<VkProfilerPerformanceCounterResultEXT>  m_VendorMetrics = {};
 
-        std::unordered_map<VkQueue, uint64_t>               m_SyncTimestamps = {};
+        DeviceProfilerSynchronizationTimestamps             m_SyncTimestamps = {};
     };
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
@@ -44,7 +44,7 @@ namespace Profiler
     {
         VkQueue                                         m_Handle = {};
         ContainerType<DeviceProfilerSubmit>             m_Submits = {};
-        std::chrono::high_resolution_clock::time_point  m_Timestamp = {};
+        uint64_t                                        m_Timestamp = {};
         uint32_t                                        m_ThreadId = {};
     };
 

--- a/VkLayer_profiler_layer/profiler/profiler_sync.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_sync.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Lukasz Stalmirski
+// Copyright (c) 2019-2024 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,8 @@
 // SOFTWARE.
 
 #include "profiler_sync.h"
-#include "profiler_helpers.h"
+#include "profiler_counters.h"
+#include "profiler_data.h"
 #include <assert.h>
 
 namespace Profiler
@@ -35,14 +36,11 @@ namespace Profiler
     \***********************************************************************************/
     DeviceProfilerSynchronization::DeviceProfilerSynchronization()
         : m_pDevice( nullptr )
-        , m_CommandPools()
-        , m_CommandBuffers()
-        , m_TimestampQueryPoolSize( 0 )
-        , m_TimestampQueryPool( VK_NULL_HANDLE )
-        , m_TimestampQueryPoolResetCommandBuffer( VK_NULL_HANDLE )
-        , m_TimestampQueryPoolResetSemaphore( VK_NULL_HANDLE )
-        , m_TimestampQueryPoolResetQueue( VK_NULL_HANDLE )
-        , m_SynchronizationTimestampsSent( false )
+        , m_pfnGetCalibratedTimestampsEXT( nullptr )
+        , m_HostTimeDomain( OSGetDefaultTimeDomain() )
+        , m_DeviceTimeDomain( VK_TIME_DOMAIN_DEVICE_EXT )
+        , m_HostCalibratedTimestamp( 0 )
+        , m_DeviceCalibratedTimestamp( 0 )
     {
     }
 
@@ -57,96 +55,65 @@ namespace Profiler
     \***********************************************************************************/
     VkResult DeviceProfilerSynchronization::Initialize( VkDevice_Object* pDevice )
     {
-        assert( !m_pDevice );
+        VkResult result = VK_SUCCESS;
         m_pDevice = pDevice;
 
-        m_TimestampQueryPoolSize = static_cast<uint32_t>(m_pDevice->Queues.size());
-
-        // Create a command pool for each queue family
-        VkCommandPoolCreateInfo commandPoolCreateInfo = {};
-        commandPoolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-
-        for( const auto& queue : m_pDevice->Queues )
+        // Use VK_EXT_calibrated_timestamps (or KHR equivalent).
+        if( m_pDevice != nullptr )
         {
-            if( !m_CommandPools.count( queue.second.Family ) )
+            PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT pfnGetPhysicalDeviceCalibrateableTimeDomainsEXT = nullptr;
+
+            // Use the available extension.
+            if( m_pDevice->EnabledExtensions.count( VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME ) )
             {
-                commandPoolCreateInfo.queueFamilyIndex = queue.second.Family;
+                m_pfnGetCalibratedTimestampsEXT = m_pDevice->Callbacks.GetCalibratedTimestampsKHR;
+                pfnGetPhysicalDeviceCalibrateableTimeDomainsEXT =
+                    m_pDevice->pInstance->Callbacks.GetPhysicalDeviceCalibrateableTimeDomainsKHR;
+            }
+            else if( m_pDevice->EnabledExtensions.count( VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME ) )
+            {
+                m_pfnGetCalibratedTimestampsEXT = m_pDevice->Callbacks.GetCalibratedTimestampsEXT;
+                pfnGetPhysicalDeviceCalibrateableTimeDomainsEXT =
+                    m_pDevice->pInstance->Callbacks.GetPhysicalDeviceCalibrateableTimeDomainsEXT;
+            }
+            else
+            {
+                result = VK_ERROR_EXTENSION_NOT_PRESENT;
+            }
 
-                VkCommandPool commandPool = VK_NULL_HANDLE;
-                DESTROYANDRETURNONFAIL( m_pDevice->Callbacks.CreateCommandPool(
-                    m_pDevice->Handle, &commandPoolCreateInfo, nullptr, &commandPool ) );
+            // Enumerate available time domains.
+            if( result == VK_SUCCESS && pfnGetPhysicalDeviceCalibrateableTimeDomainsEXT != nullptr )
+            {
+                uint32_t calibrateableTimeDomainCount = 0;
+                result = pfnGetPhysicalDeviceCalibrateableTimeDomainsEXT(
+                    m_pDevice->pPhysicalDevice->Handle,
+                    &calibrateableTimeDomainCount,
+                    nullptr );
 
-                m_CommandPools.insert( std::pair( queue.second.Family, commandPool ) );
+                std::vector<VkTimeDomainEXT> calibrateableTimeDomains( calibrateableTimeDomainCount );
+                if( result == VK_SUCCESS && calibrateableTimeDomainCount > 0 )
+                {
+                    result = pfnGetPhysicalDeviceCalibrateableTimeDomainsEXT(
+                        m_pDevice->pPhysicalDevice->Handle,
+                        &calibrateableTimeDomainCount,
+                        calibrateableTimeDomains.data() );
+                }
+
+                if( result == VK_SUCCESS && calibrateableTimeDomainCount > 0 )
+                {
+                    m_HostTimeDomain = OSGetPreferredTimeDomain(
+                        calibrateableTimeDomainCount,
+                        calibrateableTimeDomains.data() );
+                }
+            }
+
+            if( result != VK_SUCCESS )
+            {
+                // Query of timestamp calibration capabilities failed.
+                // Disable the extension.
+                m_pfnGetCalibratedTimestampsEXT = nullptr;
             }
         }
-
-        // Create command buffer for each queue
-        VkCommandBufferAllocateInfo commandBufferAllocateInfo = {};
-        commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-        commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-        commandBufferAllocateInfo.commandBufferCount = 1;
-
-        for( const auto& queue : m_pDevice->Queues )
-        {
-            // Get command pool created in the previous step
-            commandBufferAllocateInfo.commandPool = m_CommandPools.at( queue.second.Family );
-
-            VkCommandBuffer commandBuffer = VK_NULL_HANDLE;
-            DESTROYANDRETURNONFAIL( m_pDevice->Callbacks.AllocateCommandBuffers(
-                m_pDevice->Handle, &commandBufferAllocateInfo, &commandBuffer ) );
-
-            // Created object must be stored to ensure it is destroyed when next call fails.
-            m_CommandBuffers.insert( std::pair( queue.second.Handle, commandBuffer ) );
-
-            DESTROYANDRETURNONFAIL( m_pDevice->SetDeviceLoaderData(
-                m_pDevice->Handle, commandBuffer ) );
-        }
-
-        // Create query pool for timestamp queries
-        VkQueryPoolCreateInfo queryPoolCreateInfo = {};
-        queryPoolCreateInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
-        queryPoolCreateInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
-        queryPoolCreateInfo.queryCount = m_TimestampQueryPoolSize;
-        
-        DESTROYANDRETURNONFAIL( m_pDevice->Callbacks.CreateQueryPool(
-            m_pDevice->Handle, &queryPoolCreateInfo, nullptr, &m_TimestampQueryPool ) );
-
-        // Select queue used for resetting the query pool
-        commandBufferAllocateInfo.commandPool = VK_NULL_HANDLE;
-
-        for( const auto& queue : m_pDevice->Queues )
-        {
-            if( (queue.second.Flags & VK_QUEUE_GRAPHICS_BIT) ||
-                (queue.second.Flags & VK_QUEUE_COMPUTE_BIT) )
-            {
-                m_TimestampQueryPoolResetQueue = queue.second.Handle;
-                // Use command pool created for the queue family
-                commandBufferAllocateInfo.commandPool = m_CommandPools.at( queue.second.Family );
-                break;
-            }
-        }
-
-        if( commandBufferAllocateInfo.commandPool == VK_NULL_HANDLE )
-        {
-            // Application didn't create any graphics/compute queues (?!)
-            DESTROYANDRETURNONFAIL( VK_ERROR_INITIALIZATION_FAILED );
-        }
-
-        // Create prerecorded command buffer resetting the query pool
-        DESTROYANDRETURNONFAIL( m_pDevice->Callbacks.AllocateCommandBuffers(
-            m_pDevice->Handle, &commandBufferAllocateInfo, &m_TimestampQueryPoolResetCommandBuffer ) );
-
-        DESTROYANDRETURNONFAIL( m_pDevice->SetDeviceLoaderData(
-            m_pDevice->Handle, m_TimestampQueryPoolResetCommandBuffer ) );
-
-        DESTROYANDRETURNONFAIL( RecordTimestmapQueryCommandBuffers() );
-
-        // Create semaphore for synchronization between queues
-        VkSemaphoreCreateInfo semaphoreCreateInfo = {};
-        semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        
-        DESTROYANDRETURNONFAIL( m_pDevice->Callbacks.CreateSemaphore(
-            m_pDevice->Handle, &semaphoreCreateInfo, nullptr, &m_TimestampQueryPoolResetSemaphore ) );
 
         return VK_SUCCESS;
     }
@@ -162,39 +129,12 @@ namespace Profiler
     \***********************************************************************************/
     void DeviceProfilerSynchronization::Destroy()
     {
-        // Destroy semaphore
-        if( m_TimestampQueryPoolResetSemaphore != VK_NULL_HANDLE )
-        {
-            m_pDevice->Callbacks.DestroySemaphore( m_pDevice->Handle, m_TimestampQueryPoolResetSemaphore, nullptr );
-            m_TimestampQueryPoolResetSemaphore = VK_NULL_HANDLE;
-        }
-
-        // Command buffer will be destroyed with command pool
-        m_TimestampQueryPoolResetCommandBuffer = VK_NULL_HANDLE;
-        m_TimestampQueryPoolResetQueue = VK_NULL_HANDLE;
-
-        // Destroy timestamp query pool
-        if( m_TimestampQueryPool != VK_NULL_HANDLE )
-        {
-            m_pDevice->Callbacks.DestroyQueryPool( m_pDevice->Handle, m_TimestampQueryPool, nullptr );
-            m_TimestampQueryPool = VK_NULL_HANDLE;
-        }
-
-        // Command buffers will be destroyed with command pools
-        m_CommandBuffers.clear();
-
-        // Destroy command pools
-        for( auto& commandPool : m_CommandPools )
-        {
-            if( commandPool.second != VK_NULL_HANDLE )
-            {
-                m_pDevice->Callbacks.DestroyCommandPool( m_pDevice->Handle, commandPool.second, nullptr );
-            }
-        }
-        m_CommandPools.clear();
-
-        m_TimestampQueryPoolSize = 0;
         m_pDevice = nullptr;
+        m_pfnGetCalibratedTimestampsEXT = nullptr;
+        m_HostTimeDomain = OSGetDefaultTimeDomain();
+        m_DeviceTimeDomain = VK_TIME_DOMAIN_DEVICE_EXT;
+        m_HostCalibratedTimestamp = 0;
+        m_DeviceCalibratedTimestamp = 0;
     }
 
     /***********************************************************************************\
@@ -248,45 +188,55 @@ namespace Profiler
         SendSynchronizationTimestamps
 
     Description:
-        Submit command buffers with synchronization timestamps to all queues.
-        Device must be idle.
+        Calibrate timestamps.
 
     \***********************************************************************************/
     void DeviceProfilerSynchronization::SendSynchronizationTimestamps()
     {
-        // For some reason this code causes hangs on Ubuntu with nvidia-driver-510.
-        // Validation layer doesn't report any issues, so it may be a driver bug.
-        // TODO: Check other drivers/gpus.
-#if !defined( __linux__ )
         assert( m_pDevice );
 
-        // Reset query pool
-        VkSubmitInfo submitInfo = {};
-        submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-        submitInfo.commandBufferCount = 1;
-        submitInfo.pCommandBuffers = &m_TimestampQueryPoolResetCommandBuffer;
-        submitInfo.signalSemaphoreCount = 1;
-        submitInfo.pSignalSemaphores = &m_TimestampQueryPoolResetSemaphore;
-        
-        m_pDevice->Callbacks.QueueSubmit(
-            m_TimestampQueryPoolResetQueue, 1, &submitInfo, VK_NULL_HANDLE );
-
-        // Insert timestamps when the pool is ready
-        VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-        submitInfo.waitSemaphoreCount = 1;
-        submitInfo.pWaitSemaphores = &m_TimestampQueryPoolResetSemaphore;
-        submitInfo.pWaitDstStageMask = &waitStage;
-        submitInfo.signalSemaphoreCount = 0;
-        submitInfo.pSignalSemaphores = nullptr;
-
-        for( const auto& [commandQueue, commandBuffer] : m_CommandBuffers )
+        VkResult result = VK_ERROR_EXTENSION_NOT_PRESENT;
+        if( m_pfnGetCalibratedTimestampsEXT != nullptr )
         {
-            submitInfo.pCommandBuffers = &commandBuffer;
-            m_pDevice->Callbacks.QueueSubmit( commandQueue, 1, &submitInfo, VK_NULL_HANDLE );
+            // Collected timestamp types.
+            enum : uint32_t
+            {
+                eHostTimestamp,
+                eDeviceTimestamp,
+                eTimestampCount
+            };
+
+            VkCalibratedTimestampInfoEXT timestampInfos[ eTimestampCount ] = {};
+            timestampInfos[ eHostTimestamp ].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
+            timestampInfos[ eHostTimestamp ].timeDomain = m_HostTimeDomain;
+            timestampInfos[ eDeviceTimestamp ].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
+            timestampInfos[ eDeviceTimestamp ].timeDomain = m_DeviceTimeDomain;
+
+            uint64_t timestamps[ eTimestampCount ] = {};
+            uint64_t maxDeviations[ eTimestampCount ] = {};
+
+            // Get the calibrated timestamps.
+            // TODO: maxDeviations can be used to evaluate whether the calibration was successful.
+            result = m_pfnGetCalibratedTimestampsEXT(
+                m_pDevice->Handle,
+                eTimestampCount,
+                timestampInfos,
+                timestamps,
+                maxDeviations );
+
+            if( result == VK_SUCCESS )
+            {
+                m_HostCalibratedTimestamp = timestamps[ eHostTimestamp ];
+                m_DeviceCalibratedTimestamp = timestamps[ eDeviceTimestamp ];
+            }
         }
 
-        m_SynchronizationTimestampsSent = true;
-#endif
+        // Calibration failed, timestamps not available.
+        if( result != VK_SUCCESS )
+        {
+            m_HostCalibratedTimestamp = 0;
+            m_DeviceCalibratedTimestamp = 0;
+        }
     }
 
     /***********************************************************************************\
@@ -296,88 +246,42 @@ namespace Profiler
 
     Description:
         Retrieve timestamps submitted in SendSynchronizationTimestamps.
-        Device must be idle.
 
     \***********************************************************************************/
-    std::unordered_map<VkQueue, uint64_t> DeviceProfilerSynchronization::GetSynchronizationTimestamps() const
+    DeviceProfilerSynchronizationTimestamps DeviceProfilerSynchronization::GetSynchronizationTimestamps() const
     {
-        std::unordered_map<VkQueue, uint64_t> perQueueTimestamps;
-
-        if( m_SynchronizationTimestampsSent )
-        {
-            // Collect pending queries
-            std::vector<uint64_t> timestamps( m_TimestampQueryPoolSize );
-            m_pDevice->Callbacks.GetQueryPoolResults(
-                m_pDevice->Handle, m_TimestampQueryPool, 0, m_TimestampQueryPoolSize,
-                sizeof( uint64_t ) * timestamps.size(), timestamps.data(), sizeof( uint64_t ),
-                VK_QUERY_RESULT_64_BIT );
-
-            // Assign queries to the queues
-            size_t currentTimestampIndex = 0;
-
-            for( const auto& commandBuffer : m_CommandBuffers )
-            {
-                perQueueTimestamps.insert( std::pair( commandBuffer.first, timestamps[ currentTimestampIndex ] ) );
-                currentTimestampIndex++;
-            }
-        }
-        else
-        {
-            // Synchronization timestamps not sent, return zeros
-            for( const auto& commandBuffer : m_CommandBuffers )
-            {
-                perQueueTimestamps.insert( std::pair( commandBuffer.first, 0 ) );
-            }
-        }
-
-        return perQueueTimestamps;
+        DeviceProfilerSynchronizationTimestamps syncTimestamps;
+        syncTimestamps.m_HostTimeDomain = m_HostTimeDomain;
+        syncTimestamps.m_HostCalibratedTimestamp = m_HostCalibratedTimestamp;
+        syncTimestamps.m_DeviceCalibratedTimestamp = m_DeviceCalibratedTimestamp;
+        return syncTimestamps;
     }
 
     /***********************************************************************************\
 
     Function:
-        RecordTimestmapQueryCommandBuffers
+        GetHostTimeDomain
 
     Description:
+        Returns time domain selected for host timestamps.
 
     \***********************************************************************************/
-    VkResult DeviceProfilerSynchronization::RecordTimestmapQueryCommandBuffers()
+    VkTimeDomainEXT DeviceProfilerSynchronization::GetHostTimeDomain() const
     {
-        // Record query reset command buffer
-        VkCommandBufferBeginInfo beginInfo = {};
-        beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-        
-        RETURNONFAIL( m_pDevice->Callbacks.BeginCommandBuffer(
-            m_TimestampQueryPoolResetCommandBuffer, &beginInfo ) );
+        return m_HostTimeDomain;
+    }
 
-        m_pDevice->Callbacks.CmdResetQueryPool(
-            m_TimestampQueryPoolResetCommandBuffer,
-            m_TimestampQueryPool,
-            0, m_TimestampQueryPoolSize );
+    /***********************************************************************************\
 
-        RETURNONFAIL( m_pDevice->Callbacks.EndCommandBuffer(
-            m_TimestampQueryPoolResetCommandBuffer ) );
+    Function:
+        GetDeviceTimeDomain
 
-        // Record synchronization command buffers
-        uint32_t currentTimestampIndex = 0;
+    Description:
+        Returns time domain used by GPU timestamps.
 
-        for( const auto& commandBuffer : m_CommandBuffers )
-        {
-            RETURNONFAIL( m_pDevice->Callbacks.BeginCommandBuffer(
-                commandBuffer.second, &beginInfo ) );
-
-            m_pDevice->Callbacks.CmdWriteTimestamp(
-                commandBuffer.second,
-                VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                m_TimestampQueryPool,
-                currentTimestampIndex );
-
-            RETURNONFAIL( m_pDevice->Callbacks.EndCommandBuffer(
-                commandBuffer.second ) );
-
-            currentTimestampIndex++;
-        }
-
-        return VK_SUCCESS;
+    \***********************************************************************************/
+    VkTimeDomainEXT DeviceProfilerSynchronization::GetDeviceTimeDomain() const
+    {
+        return m_DeviceTimeDomain;
     }
 }

--- a/VkLayer_profiler_layer/profiler/profiler_sync.h
+++ b/VkLayer_profiler_layer/profiler/profiler_sync.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Lukasz Stalmirski
+// Copyright (c) 2019-2024 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 namespace Profiler
 {
     class ProfilerCommandBuffer;
+    struct DeviceProfilerSynchronizationTimestamps;
 
     /***********************************************************************************\
 
@@ -47,25 +48,20 @@ namespace Profiler
         void WaitForFence( VkFence fence, uint64_t timeout = std::numeric_limits<uint64_t>::max() );
 
         void SendSynchronizationTimestamps();
-        std::unordered_map<VkQueue, uint64_t> GetSynchronizationTimestamps() const;
+        DeviceProfilerSynchronizationTimestamps GetSynchronizationTimestamps() const;
+
+        VkTimeDomainEXT GetHostTimeDomain() const;
+        VkTimeDomainEXT GetDeviceTimeDomain() const;
 
     private:
         VkDevice_Object* m_pDevice;
 
-        // Command pool for each queue family
-        std::unordered_map<uint32_t, VkCommandPool> m_CommandPools;
-        // Command buffer for each queue
-        std::unordered_map<VkQueue, VkCommandBuffer> m_CommandBuffers;
+        PFN_vkGetCalibratedTimestampsEXT m_pfnGetCalibratedTimestampsEXT;
 
-        uint32_t m_TimestampQueryPoolSize;
-        VkQueryPool m_TimestampQueryPool;
-        // Resources needed to reset query pool
-        VkCommandBuffer m_TimestampQueryPoolResetCommandBuffer;
-        VkSemaphore m_TimestampQueryPoolResetSemaphore;
-        VkQueue m_TimestampQueryPoolResetQueue;
+        VkTimeDomainEXT m_HostTimeDomain;
+        VkTimeDomainEXT m_DeviceTimeDomain;
 
-        bool m_SynchronizationTimestampsSent;
-
-        VkResult RecordTimestmapQueryCommandBuffers();
+        uint64_t        m_HostCalibratedTimestamp;
+        uint64_t        m_DeviceCalibratedTimestamp;
     };
 }

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkQueue_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkQueue_functions.cpp
@@ -37,12 +37,15 @@ namespace Profiler
         VkFence fence )
     {
         auto& dd = DeviceDispatch.Get( queue );
-        dd.Profiler.PreSubmitCommandBuffers( queue );
+
+        DeviceProfilerSubmitBatch submitBatch;
+        dd.Profiler.CreateSubmitBatchInfo( queue, submitCount, pSubmits, &submitBatch );
+        dd.Profiler.PreSubmitCommandBuffers( submitBatch );
 
         // Submit the command buffers
         VkResult result = dd.Device.Callbacks.QueueSubmit( queue, submitCount, pSubmits, fence );
 
-        dd.Profiler.PostSubmitCommandBuffers( queue, submitCount, pSubmits );
+        dd.Profiler.PostSubmitCommandBuffers( submitBatch );
         return result;
     }
 
@@ -61,12 +64,15 @@ namespace Profiler
         VkFence fence )
     {
         auto& dd = DeviceDispatch.Get( queue );
-        dd.Profiler.PreSubmitCommandBuffers( queue );
+
+        DeviceProfilerSubmitBatch submitBatch;
+        dd.Profiler.CreateSubmitBatchInfo( queue, submitCount, pSubmits, &submitBatch );
+        dd.Profiler.PreSubmitCommandBuffers( submitBatch );
 
         // Submit the command buffers
         VkResult result = dd.Device.Callbacks.QueueSubmit2( queue, submitCount, pSubmits, fence );
 
-        dd.Profiler.PostSubmitCommandBuffers( queue, submitCount, pSubmits );
+        dd.Profiler.PostSubmitCommandBuffers( submitBatch );
         return result;
     }
 }

--- a/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkSynchronization2Khr_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkSynchronization2Khr_functions.cpp
@@ -37,12 +37,15 @@ namespace Profiler
         VkFence fence )
     {
         auto& dd = DeviceDispatch.Get( queue );
-        dd.Profiler.PreSubmitCommandBuffers( queue );
+
+        DeviceProfilerSubmitBatch submitBatch;
+        dd.Profiler.CreateSubmitBatchInfo( queue, submitCount, pSubmits, &submitBatch );
+        dd.Profiler.PreSubmitCommandBuffers( submitBatch );
 
         // Submit the command buffers
         VkResult result = dd.Device.Callbacks.QueueSubmit2KHR( queue, submitCount, pSubmits, fence );
 
-        dd.Profiler.PostSubmitCommandBuffers( queue, submitCount, pSubmits );
+        dd.Profiler.PostSubmitCommandBuffers( submitBatch );
         return result;
     }
 

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -1311,8 +1311,10 @@ namespace Profiler
     {
         // Header
         {
+            const uint64_t cpuTimestampFreq = OSGetTimestampFrequency( m_Data.m_SyncTimestamps.m_HostTimeDomain );
             const Milliseconds gpuTimeMs = m_Data.m_Ticks * m_TimestampPeriod;
-            const Milliseconds cpuTimeMs = m_Data.m_CPU.m_EndTimestamp - m_Data.m_CPU.m_BeginTimestamp;
+            const Milliseconds cpuTimeMs = std::chrono::nanoseconds(
+                ((m_Data.m_CPU.m_EndTimestamp - m_Data.m_CPU.m_BeginTimestamp) * 1'000'000'000) / cpuTimestampFreq );
 
             ImGui::Text( "%s: %.2f ms", Lang::GPUTime, gpuTimeMs.count() );
             ImGui::Text( "%s: %.2f ms", Lang::CPUTime, cpuTimeMs.count() );

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Lukasz Stalmirski
+// Copyright (c) 2019-2024 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@
 #include "profiler_trace_event.h"
 #include "profiler_json.h"
 #include "profiler/profiler_data.h"
+#include "profiler/profiler_counters.h"
 #include "profiler/profiler_helpers.h"
 #include "profiler_layer_objects/VkObject.h"
 #include "profiler_helpers/profiler_data_helpers.h"
@@ -92,8 +93,10 @@ namespace Profiler
         , m_CommandQueue( VK_NULL_HANDLE )
         , m_pEvents()
         , m_DebugLabelStackDepth( 0 )
-        , m_CpuQueueSubmitTimestampOffset( 0 )
-        , m_GpuQueueSubmitTimestampOffset( 0 )
+        , m_HostTimeDomain( OSGetDefaultTimeDomain() )
+        , m_HostCalibratedTimestamp( 0 )
+        , m_DeviceCalibratedTimestamp( 0 )
+        , m_HostTimestampFrequency( OSGetTimestampFrequency( m_HostTimeDomain ) )
         , m_GpuTimestampPeriod( gpuTimestampPeriod )
     {
         // Initialize JSON serializer
@@ -152,7 +155,7 @@ namespace Profiler
                         TraceEvent::Phase::eFlowEnd,
                         m_pStringSerializer->GetName( waitSemaphore ),
                         "Synchronization",
-                        GetNormalizedGpuTimestamp( submitData.m_BeginTimestamp ),
+                        GetNormalizedGpuTimestamp( submitData.m_BeginTimestamp.m_Value ),
                         m_CommandQueue ) );
                 }
                 #endif
@@ -169,7 +172,7 @@ namespace Profiler
                         TraceEvent::Phase::eFlowStart,
                         m_pStringSerializer->GetName( signalSemaphpre ),
                         "Synchronization",
-                        GetNormalizedGpuTimestamp( submitData.m_EndTimestamp ),
+                        GetNormalizedGpuTimestamp( submitData.m_EndTimestamp.m_Value ),
                         m_CommandQueue ) );
                 }
                 #endif
@@ -206,33 +209,43 @@ namespace Profiler
     {
         m_CommandQueue = queue;
 
-        m_CpuQueueSubmitTimestampOffset = Milliseconds( 0 );
+        // Try to use calibrated timestamps if available.
+        m_HostTimeDomain = m_pData->m_SyncTimestamps.m_HostTimeDomain;
+        m_HostCalibratedTimestamp = m_pData->m_SyncTimestamps.m_HostCalibratedTimestamp;
+        m_DeviceCalibratedTimestamp = m_pData->m_SyncTimestamps.m_DeviceCalibratedTimestamp;
+        m_HostTimestampFrequency = OSGetTimestampFrequency( m_HostTimeDomain );
 
-        // Get base command buffer offset.
-        // Better CPU-GPU correlation could be achieved from ETLs
-        m_GpuQueueSubmitTimestampOffset = m_pData->m_SyncTimestamps.at( queue );
-
-        for( const auto& submitBatchData : m_pData->m_Submits )
+        // Manually select calibration timestamps from the data.
+        if( m_HostCalibratedTimestamp == 0 )
         {
-            if( submitBatchData.m_Handle == queue )
-            {
-                m_CpuQueueSubmitTimestampOffset = GetNormalizedCpuTimestamp( submitBatchData.m_Timestamp );
-
-                // Use first submitted packet's begin timestamp as a reference if synchronization timestamps were not sent.
-                if( m_GpuQueueSubmitTimestampOffset == 0 )
-                {
-                    m_GpuQueueSubmitTimestampOffset = !submitBatchData.m_Submits.empty()
-                        ? submitBatchData.m_Submits.front().m_BeginTimestamp.m_Value
-                        : 0;
-                }
-                break;
-            }
+            m_HostCalibratedTimestamp = m_pData->m_CPU.m_BeginTimestamp;
         }
 
-        // If no timestamps were recorded in the command buffer, apply no offset
-        if( m_GpuQueueSubmitTimestampOffset == -1 )
+        // Use first submitted packet's begin timestamp as a reference if synchronization timestamps were not sent.
+        if( m_DeviceCalibratedTimestamp == 0 )
         {
-            m_GpuQueueSubmitTimestampOffset = 0;
+            for( const DeviceProfilerSubmitBatchData& submitBatch : m_pData->m_Submits )
+            {
+                if( submitBatch.m_Handle != queue )
+                {
+                    continue;
+                }
+
+                for( const DeviceProfilerSubmitData& submit : submitBatch.m_Submits )
+                {
+                    uint64_t gpuTimestamp = submit.GetBeginTimestamp().m_Value;
+                    if( gpuTimestamp )
+                    {
+                        m_DeviceCalibratedTimestamp = gpuTimestamp;
+                        break;
+                    }
+                }
+
+                if( m_DeviceCalibratedTimestamp != 0 )
+                {
+                    break;
+                }
+            }
         }
     }
 
@@ -245,11 +258,12 @@ namespace Profiler
         Get CPU timestamp aligned to the frame begin CPU timestamp.
 
     \*************************************************************************/
-    Milliseconds DeviceProfilerTraceSerializer::GetNormalizedCpuTimestamp( std::chrono::high_resolution_clock::time_point timestamp ) const
+    Milliseconds DeviceProfilerTraceSerializer::GetNormalizedCpuTimestamp( uint64_t timestamp ) const
     {
         assert( timestamp >= m_pData->m_CPU.m_BeginTimestamp );
         assert( timestamp <= m_pData->m_CPU.m_EndTimestamp );
-        return timestamp - m_pData->m_CPU.m_BeginTimestamp;
+        return std::chrono::duration_cast<Milliseconds>(std::chrono::nanoseconds(
+            ((timestamp - m_HostCalibratedTimestamp) * 1'000'000'000) / m_HostTimestampFrequency ));
     }
 
     /*************************************************************************\
@@ -263,8 +277,7 @@ namespace Profiler
     \*************************************************************************/
     Milliseconds DeviceProfilerTraceSerializer::GetNormalizedGpuTimestamp( uint64_t gpuTimestamp ) const
     {
-        return m_CpuQueueSubmitTimestampOffset +
-            ((gpuTimestamp - m_GpuQueueSubmitTimestampOffset) * m_GpuTimestampPeriod);
+        return ((gpuTimestamp - m_DeviceCalibratedTimestamp) * m_GpuTimestampPeriod);
     }
 
     /*************************************************************************\

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.h
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Lukasz Stalmirski
+// Copyright (c) 2019-2024 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -92,12 +92,14 @@ namespace Profiler
         uint32_t     m_DebugLabelStackDepth;
 
         // Timestamp normalization
-        Milliseconds m_CpuQueueSubmitTimestampOffset;
-        uint64_t     m_GpuQueueSubmitTimestampOffset;
+        VkTimeDomainEXT m_HostTimeDomain;
+        uint64_t     m_HostCalibratedTimestamp;
+        uint64_t     m_DeviceCalibratedTimestamp;
+        uint64_t     m_HostTimestampFrequency;
         Milliseconds m_GpuTimestampPeriod;
 
         void SetupTimestampNormalizationConstants( VkQueue );
-        Milliseconds GetNormalizedCpuTimestamp( std::chrono::high_resolution_clock::time_point ) const;
+        Milliseconds GetNormalizedCpuTimestamp( uint64_t ) const;
         Milliseconds GetNormalizedGpuTimestamp( uint64_t ) const;
 
         template<typename DataStructType>


### PR DESCRIPTION
Rewrite CPU counters to use QueryPerformanceCounter on Windows and monotonic timestamps on Linux.