### PR TITLE
Skip data from command buffers that were not instrumented.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
@@ -92,7 +92,6 @@ namespace Profiler
         const VkCommandBufferLevel          m_Level;
 
         bool                                m_ProfilingEnabled;
-        bool                                m_Dirty;
 
         std::unordered_set<VkCommandBuffer> m_SecondaryCommandBuffers;
 

--- a/VkLayer_profiler_layer/profiler/profiler_command_pool.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_pool.cpp
@@ -34,13 +34,23 @@ namespace Profiler
     \***********************************************************************************/
     DeviceProfilerCommandPool::DeviceProfilerCommandPool( DeviceProfiler& profiler, VkCommandPool commandPool, const VkCommandPoolCreateInfo& createInfo )
         : m_CommandPool( commandPool )
-        , m_CommandQueueFlags( 0 )
+        , m_SupportsTimestampQuery( false )
     {
         // Get target command queue family properties
         const VkQueueFamilyProperties& queueFamilyProperties =
             profiler.m_pDevice->pPhysicalDevice->QueueFamilyProperties[ createInfo.queueFamilyIndex ];
 
-        m_CommandQueueFlags = queueFamilyProperties.queueFlags;
+        // Profile the command buffer only if it will be submitted to the queue supporting graphics or compute commands
+        // This is requirement of vkCmdResetQueryPool (VUID-vkCmdResetQueryPool-commandBuffer-cmdpool)
+        const bool canResetQueryPool =
+            (profiler.m_pfnResetQueryPool != nullptr) ||
+            (queueFamilyProperties.queueFlags & ( VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT ));
+
+        // Profile only queues that support timestamp queries (VUID-vkCmdWriteTimestamp-timestampValidBits-00829)
+        if( canResetQueryPool && queueFamilyProperties.timestampValidBits != 0 )
+        {
+            m_SupportsTimestampQuery = true;
+        }
     }
 
     /***********************************************************************************\
@@ -66,8 +76,8 @@ namespace Profiler
         Get flags of target command queue.
 
     \***********************************************************************************/
-    VkQueueFlags DeviceProfilerCommandPool::GetCommandQueueFlags() const
+    bool DeviceProfilerCommandPool::SupportsTimestampQuery() const
     {
-        return m_CommandQueueFlags;
+        return m_SupportsTimestampQuery;
     }
 }

--- a/VkLayer_profiler_layer/profiler/profiler_command_pool.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_pool.cpp
@@ -43,8 +43,11 @@ namespace Profiler
         // Profile the command buffer only if it will be submitted to the queue supporting graphics or compute commands
         // This is requirement of vkCmdResetQueryPool (VUID-vkCmdResetQueryPool-commandBuffer-cmdpool)
         const bool canResetQueryPool =
-            (profiler.m_pfnResetQueryPool != nullptr) ||
-            (queueFamilyProperties.queueFlags & ( VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT ));
+            (queueFamilyProperties.queueFlags & (
+                VK_QUEUE_GRAPHICS_BIT |
+                VK_QUEUE_COMPUTE_BIT |
+                VK_QUEUE_VIDEO_DECODE_BIT_KHR |
+                VK_QUEUE_VIDEO_ENCODE_BIT_KHR ));
 
         // Profile only queues that support timestamp queries (VUID-vkCmdWriteTimestamp-timestampValidBits-00829)
         if( canResetQueryPool && queueFamilyProperties.timestampValidBits != 0 )

--- a/VkLayer_profiler_layer/profiler/profiler_command_pool.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_pool.h
@@ -40,10 +40,10 @@ namespace Profiler
         DeviceProfilerCommandPool( const DeviceProfilerCommandPool& ) = delete;
 
         VkCommandPool GetHandle() const;
-        VkQueueFlags GetCommandQueueFlags() const;
+        bool SupportsTimestampQuery() const;
 
     private:
         VkCommandPool m_CommandPool;
-        VkQueueFlags  m_CommandQueueFlags;
+        bool m_SupportsTimestampQuery;
     };
 }

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -1138,6 +1138,8 @@ namespace Profiler
         DeviceProfilerTimestamp                             m_BeginTimestamp;
         DeviceProfilerTimestamp                             m_EndTimestamp;
 
+        bool                                                m_DataValid = false;
+
         ContainerType<struct DeviceProfilerRenderPassData>  m_RenderPasses = {};
 
         std::vector<VkProfilerPerformanceCounterResultEXT>  m_PerformanceQueryResults = {};

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
@@ -222,10 +222,14 @@ namespace Profiler
                         }
                     }
 
-                    submitData.m_BeginTimestamp.m_Value = std::min(
-                        submitData.m_BeginTimestamp.m_Value, submitData.m_CommandBuffers.back().m_BeginTimestamp.m_Value );
-                    submitData.m_EndTimestamp.m_Value = std::max(
-                        submitData.m_EndTimestamp.m_Value, submitData.m_CommandBuffers.back().m_EndTimestamp.m_Value );
+                    // Update submission timestamps.
+                    if( !submitData.m_CommandBuffers.empty() )
+                    {
+                        submitData.m_BeginTimestamp.m_Value = std::min(
+                            submitData.m_BeginTimestamp.m_Value, submitData.m_CommandBuffers.back().m_BeginTimestamp.m_Value );
+                        submitData.m_EndTimestamp.m_Value = std::max(
+                            submitData.m_EndTimestamp.m_Value, submitData.m_CommandBuffers.back().m_EndTimestamp.m_Value );
+                    }
                 }
             }
         }

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
@@ -204,12 +204,22 @@ namespace Profiler
                     auto it = data.find( pCommandBuffer );
                     if( it != data.end() )
                     {
-                        submitData.m_CommandBuffers.push_back( it->second );
+                        // Skip if instrumentation was disabled for this command buffer
+                        if( it->second.m_DataValid )
+                        {
+                            submitData.m_CommandBuffers.push_back( it->second );
+                        }
                     }
                     else
                     {
                         // Collect command buffer data now
-                        submitData.m_CommandBuffers.push_back( pCommandBuffer->GetData() );
+                        auto& commandBufferData = pCommandBuffer->GetData();
+
+                        // Skip if instrumentation was disabled for this command buffer
+                        if( commandBufferData.m_DataValid )
+                        {
+                            submitData.m_CommandBuffers.push_back( commandBufferData );
+                        }
                     }
 
                     submitData.m_BeginTimestamp.m_Value = std::min(


### PR DESCRIPTION
Improve detection of queues that support timestamp query and don't aggregate data of command buffers submitted to queues that don't.