### PR TITLE
Add a context menu to command buffer nodes in frame browser.

### DIFF
--- a/VkLayer_profiler_layer/profiler_overlay/lang/en_us.h
+++ b/VkLayer_profiler_layer/profiler_overlay/lang/en_us.h
@@ -80,6 +80,7 @@ namespace Profiler
         inline static constexpr char CustomStatistics[] = "Custom statistics";
         inline static constexpr char Container[] = "Container";
         inline static constexpr char Inspect[] = "Inspect";
+        inline static constexpr char ShowPerformanceMetrics[] = "Show performance metrics";
 
         inline static constexpr char ShaderCapabilityTooltipFmt[] = "At least one shader in the pipeline uses '%s' capability.";
         inline static constexpr char ShaderObjectsTooltip[] = "Pipeline constructed from VkShaderEXT objects passed via vkCmdBindShadersEXT.";

--- a/VkLayer_profiler_layer/profiler_overlay/lang/pl_pl.h
+++ b/VkLayer_profiler_layer/profiler_overlay/lang/pl_pl.h
@@ -75,6 +75,8 @@ namespace Profiler
         inline static constexpr char Sort[] = u8"Sortowanie";
         inline static constexpr char CustomStatistics[] = u8"Własne statystyki";
         inline static constexpr char Container[] = u8"Kontener";
+        inline static constexpr char Inspect[] = u8"Inspekcja";
+        inline static constexpr char ShowPerformanceMetrics[] = u8"Pokaż liczniki wydajności";
 
         inline static constexpr char ShaderCapabilityTooltipFmt[] = u8"Co najmniej jeden shader w potoku korzysta z funkcjonalności '%s'.";
         inline static constexpr char ShaderObjectsTooltip[] = u8"Potok utworzony z objektów VkShaderEXT za pomocą vkCmdBindShadersEXT.";

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -3621,7 +3621,23 @@ namespace Profiler
         }
 
         const char* indexStr = GetFrameBrowserNodeIndexStr( index );
-        if( ImGui::TreeNode( indexStr, "%s", m_pStringSerializer->GetName( cmdBuffer.m_Handle ).c_str() ) )
+        const std::string commandBufferName = m_pStringSerializer->GetName( cmdBuffer.m_Handle );
+        bool commandBufferTreeExpanded = ImGui::TreeNode( indexStr, "%s",
+            commandBufferName.c_str() );
+
+        if( ImGui::BeginPopupContextItem() )
+        {
+            if( ImGui::MenuItem( Lang::ShowPerformanceMetrics, nullptr, nullptr, !cmdBuffer.m_PerformanceQueryResults.empty() ) )
+            {
+                m_PerformanceQueryCommandBufferFilter = cmdBuffer.m_Handle;
+                m_PerformanceQueryCommandBufferFilterName = commandBufferName;
+            }
+            ImGui::EndPopup();
+        }
+
+        PrintDuration( cmdBuffer );
+
+        if( commandBufferTreeExpanded )
         {
             // Command buffer opened
             PrintDuration( cmdBuffer );
@@ -3641,11 +3657,6 @@ namespace Profiler
 
             index.pop_back();
             ImGui::TreePop();
-        }
-        else
-        {
-            // Command buffer collapsed
-            PrintDuration( cmdBuffer );
         }
     }
 


### PR DESCRIPTION
The context menu allows to quickly filter performance metrics to the selected command buffer.