### PR TITLE
Fix implicit subpass indexing.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
@@ -52,7 +52,7 @@ namespace Profiler
         , m_pCurrentSubpassData( nullptr )
         , m_pCurrentPipelineData( nullptr )
         , m_pCurrentDrawcallData( nullptr )
-        , m_CurrentSubpassIndex( -1 )
+        , m_CurrentSubpassIndex( DeviceProfilerSubpassData::ImplicitSubpassIndex )
         , m_GraphicsPipeline()
         , m_ComputePipeline()
     {
@@ -254,7 +254,7 @@ namespace Profiler
             m_Data.m_RenderPasses.clear();
             m_SecondaryCommandBuffers.clear();
 
-            m_CurrentSubpassIndex = -1;
+            m_CurrentSubpassIndex = DeviceProfilerSubpassData::ImplicitSubpassIndex;
             m_pCurrentRenderPass = nullptr;
             m_pCurrentRenderPassData = nullptr;
             m_pCurrentSubpassData = nullptr;
@@ -398,7 +398,7 @@ namespace Profiler
             }
 
             // No more subpasses in this render pass.
-            m_CurrentSubpassIndex = -1;
+            m_CurrentSubpassIndex = DeviceProfilerSubpassData::ImplicitSubpassIndex;
             m_pCurrentRenderPass = nullptr;
             m_pCurrentRenderPassData = nullptr;
             m_pCurrentSubpassData = nullptr;
@@ -1376,7 +1376,7 @@ namespace Profiler
         // Render pass must be already tracked
         assert( !m_Data.m_RenderPasses.empty() );
 
-        if( m_CurrentSubpassIndex != -1 )
+        if( m_CurrentSubpassIndex != DeviceProfilerSubpassData::ImplicitSubpassIndex )
         {
             assert( m_pCurrentSubpassData );
 

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -1023,6 +1023,10 @@ namespace Profiler
     \***********************************************************************************/
     struct DeviceProfilerSubpassData
     {
+        // Mark subpasses that are not part of any render pass as implicit.
+        // Required to handle commands scoped outside of render pass.
+        static constexpr uint32_t                           ImplicitSubpassIndex = UINT32_MAX;
+
         uint32_t                                            m_Index = {};
         VkSubpassContents                                   m_Contents = {};
         DeviceProfilerTimestamp                             m_BeginTimestamp;


### PR DESCRIPTION
Use UINT32_MAX instead of -1 to mark and check for internally inserted subpasses, that handle commands outside of render pass scope.
Refactor PrintDuration calls and remove redundant call in PrintCommandBuffer.