### PR TITLE
Fix missing pipeline object names.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -99,7 +99,7 @@ namespace Profiler
 
         void CreatePipelines( uint32_t, const VkGraphicsPipelineCreateInfo*, VkPipeline* );
         void CreatePipelines( uint32_t, const VkComputePipelineCreateInfo*, VkPipeline* );
-        void CreatePipelines( uint32_t, const VkRayTracingPipelineCreateInfoKHR*, VkPipeline* );
+        void CreatePipelines( uint32_t, const VkRayTracingPipelineCreateInfoKHR*, VkPipeline*, bool deferred );
         void DestroyPipeline( VkPipeline );
 
         void CreateShaderModule( VkShaderModule, const VkShaderModuleCreateInfo* );
@@ -182,7 +182,7 @@ namespace Profiler
         void CreateInternalPipeline( DeviceProfilerPipelineType, const char* );
 
         void SetPipelineShaderProperties( DeviceProfilerPipeline& pipeline, uint32_t stageCount, const VkPipelineShaderStageCreateInfo* pStages );
-        void SetDefaultObjectName( const DeviceProfilerPipeline& pipeline );
+        void SetDefaultPipelineName( const DeviceProfilerPipeline& pipeline, bool deferred = false );
 
         decltype(m_pCommandBuffers)::iterator FreeCommandBuffer( VkCommandBuffer );
         decltype(m_pCommandBuffers)::iterator FreeCommandBuffer( decltype(m_pCommandBuffers)::iterator );

--- a/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkRayTracingPipelineKhr_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkRayTracingPipelineKhr_functions.cpp
@@ -69,7 +69,7 @@ namespace Profiler
                 if( pipelineCreationResult == VK_SUCCESS )
                 {
                     // Register the pipelines.
-                    dd.Profiler.CreatePipelines( createInfoCount, pCreateInfos, pPipelines );
+                    dd.Profiler.CreatePipelines( createInfoCount, pCreateInfos, pPipelines, true /*deferred*/ );
                 }
 
                 // Release pointer to the extended create info when the operation is complete.
@@ -86,7 +86,7 @@ namespace Profiler
         if( (result == VK_SUCCESS) || (result == VK_OPERATION_NOT_DEFERRED_KHR) )
         {
             // Register pipelines
-            dd.Profiler.CreatePipelines( createInfoCount, pCreateInfos, pPipelines );
+            dd.Profiler.CreatePipelines( createInfoCount, pCreateInfos, pPipelines, false );
         }
 
         free( pCreateInfosWithExecutableProperties );

--- a/VkLayer_profiler_layer/profiler_tests/CMakeLists.txt
+++ b/VkLayer_profiler_layer/profiler_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ if (BUILD_TESTS)
         "profiler_memory_tests.cpp"
         "profiler_testing_common.h"
         "profiler_vulkan_simple_triangle.h"
+        "profiler_vulkan_simple_triangle_rt.h"
         "profiler_vulkan_state.h"
         )
 

--- a/VkLayer_profiler_layer/profiler_tests/profiler_vulkan_simple_triangle.h
+++ b/VkLayer_profiler_layer/profiler_tests/profiler_vulkan_simple_triangle.h
@@ -21,8 +21,8 @@
 #pragma once
 #include "profiler_vulkan_state.h"
 
-#include "shaders/simple_triangle.vert.hlsl.h"
-#include "shaders/simple_triangle.frag.hlsl.h"
+#include "shaders/simple_triangle.vert.glsl.h"
+#include "shaders/simple_triangle.frag.glsl.h"
 
 namespace Profiler
 {
@@ -163,15 +163,15 @@ namespace Profiler
                 { // Create vertex shader module
                     VkShaderModuleCreateInfo moduleCreateInfo = {};
                     moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-                    moduleCreateInfo.codeSize = sizeof( simple_triangle_vert_hlsl );
-                    moduleCreateInfo.pCode = simple_triangle_vert_hlsl;
+                    moduleCreateInfo.codeSize = sizeof( simple_triangle_vert_glsl );
+                    moduleCreateInfo.pCode = simple_triangle_vert_glsl;
                     VERIFY_RESULT( Vk, vkCreateShaderModule( Vk->Device, &moduleCreateInfo, nullptr, &vertexShaderModule ) );
                 }
                 { // Create fragment shader module
                     VkShaderModuleCreateInfo moduleCreateInfo = {};
                     moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-                    moduleCreateInfo.codeSize = sizeof( simple_triangle_frag_hlsl );
-                    moduleCreateInfo.pCode = simple_triangle_frag_hlsl;
+                    moduleCreateInfo.codeSize = sizeof( simple_triangle_frag_glsl );
+                    moduleCreateInfo.pCode = simple_triangle_frag_glsl;
                     VERIFY_RESULT( Vk, vkCreateShaderModule( Vk->Device, &moduleCreateInfo, nullptr, &fragmentShaderModule ) );
                 }
 

--- a/VkLayer_profiler_layer/profiler_tests/profiler_vulkan_simple_triangle_rt.h
+++ b/VkLayer_profiler_layer/profiler_tests/profiler_vulkan_simple_triangle_rt.h
@@ -1,0 +1,178 @@
+// Copyright (c) 2025 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include "profiler_vulkan_state.h"
+
+#include "shaders/simple_triangle_rt.rgen.glsl.h"
+#include "shaders/simple_triangle_rt.rmiss.glsl.h"
+#include "shaders/simple_triangle_rt.rchit.glsl.h"
+
+namespace Profiler
+{
+    class VulkanSimpleTriangleRT
+    {
+    public:
+        VulkanState* Vk = nullptr;
+
+        VkPipelineLayout PipelineLayout = VK_NULL_HANDLE;
+        VkPipeline Pipeline = VK_NULL_HANDLE;
+
+        VkShaderModule RaygenShaderModule = VK_NULL_HANDLE;
+        VkShaderModule MissShaderModule = VK_NULL_HANDLE;
+        VkShaderModule HitShaderModule = VK_NULL_HANDLE;
+
+        VkRayTracingPipelineCreateInfoKHR PipelineInfo = {};
+        VkRayTracingShaderGroupCreateInfoKHR PipelineShaderGroups[3] = {};
+        VkPipelineShaderStageCreateInfo PipelineShaderStages[3] = {};
+
+        PFN_vkCreateDeferredOperationKHR vkCreateDeferredOperationKHR = nullptr;
+        PFN_vkDestroyDeferredOperationKHR vkDestroyDeferredOperationKHR = nullptr;
+        PFN_vkDeferredOperationJoinKHR vkDeferredOperationJoinKHR = nullptr;
+
+        PFN_vkCreateRayTracingPipelinesKHR vkCreateRayTracingPipelinesKHR = nullptr;
+
+    public:
+        static void ConfigureVulkan( VulkanState::CreateInfo& createInfo )
+        {
+            static VulkanExtension deferredHostOperationsExtension( VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME, true );
+            createInfo.DeviceExtensions.push_back( &deferredHostOperationsExtension );
+
+            static VulkanExtension rayTracingPipelineExtension( VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME, true );
+            createInfo.DeviceExtensions.push_back( &rayTracingPipelineExtension );
+        }
+
+        inline VulkanSimpleTriangleRT( VulkanState* Vk )
+            : Vk( Vk )
+        {
+            // Get function pointers
+            vkCreateDeferredOperationKHR = (PFN_vkCreateDeferredOperationKHR)vkGetDeviceProcAddr( Vk->Device, "vkCreateDeferredOperationKHR" );
+            vkDestroyDeferredOperationKHR = (PFN_vkDestroyDeferredOperationKHR)vkGetDeviceProcAddr( Vk->Device, "vkDestroyDeferredOperationKHR" );
+            vkDeferredOperationJoinKHR = (PFN_vkDeferredOperationJoinKHR)vkGetDeviceProcAddr( Vk->Device, "vkDeferredOperationJoinKHR" );
+
+            vkCreateRayTracingPipelinesKHR = (PFN_vkCreateRayTracingPipelinesKHR)vkGetDeviceProcAddr( Vk->Device, "vkCreateRayTracingPipelinesKHR" );
+        }
+
+        inline ~VulkanSimpleTriangleRT()
+        {
+            if( Pipeline ) vkDestroyPipeline( Vk->Device, Pipeline, nullptr );
+            if( PipelineLayout ) vkDestroyPipelineLayout( Vk->Device, PipelineLayout, nullptr );
+            if( RaygenShaderModule ) vkDestroyShaderModule( Vk->Device, RaygenShaderModule, nullptr );
+            if( MissShaderModule ) vkDestroyShaderModule( Vk->Device, MissShaderModule, nullptr );
+            if( HitShaderModule ) vkDestroyShaderModule( Vk->Device, HitShaderModule, nullptr );
+        }
+
+        inline void CreatePipeline( VkDeferredOperationKHR deferredOperation = VK_NULL_HANDLE )
+        {
+            // Create shader modules
+            VkShaderModuleCreateInfo shaderModuleInfo = {};
+            shaderModuleInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+            shaderModuleInfo.codeSize = sizeof( simple_triangle_rt_rgen_glsl );
+            shaderModuleInfo.pCode = simple_triangle_rt_rgen_glsl;
+            VERIFY_RESULT( Vk, vkCreateShaderModule( Vk->Device, &shaderModuleInfo, nullptr, &RaygenShaderModule ) );
+
+            shaderModuleInfo.codeSize = sizeof( simple_triangle_rt_rmiss_glsl );
+            shaderModuleInfo.pCode = simple_triangle_rt_rmiss_glsl;
+            VERIFY_RESULT( Vk, vkCreateShaderModule( Vk->Device, &shaderModuleInfo, nullptr, &MissShaderModule ) );
+
+            shaderModuleInfo.codeSize = sizeof( simple_triangle_rt_rchit_glsl );
+            shaderModuleInfo.pCode = simple_triangle_rt_rchit_glsl;
+            VERIFY_RESULT( Vk, vkCreateShaderModule( Vk->Device, &shaderModuleInfo, nullptr, &HitShaderModule ) );
+
+            // Create pipeline layout
+            VkPipelineLayoutCreateInfo pipelineLayoutInfo = {};
+            pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+            VERIFY_RESULT( Vk, vkCreatePipelineLayout( Vk->Device, &pipelineLayoutInfo, nullptr, &PipelineLayout ) );
+
+            // Create ray tracing pipeline
+            PipelineInfo.sType = VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR;
+            PipelineInfo.layout = PipelineLayout;
+            PipelineInfo.stageCount = 3;
+            PipelineInfo.pStages = PipelineShaderStages;
+            PipelineInfo.groupCount = 3;
+            PipelineInfo.pGroups = PipelineShaderGroups;
+
+            PipelineShaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+            PipelineShaderStages[0].stage = VK_SHADER_STAGE_RAYGEN_BIT_KHR;
+            PipelineShaderStages[0].module = RaygenShaderModule;
+            PipelineShaderStages[0].pName = "main";
+
+            PipelineShaderGroups[0].sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
+            PipelineShaderGroups[0].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
+            PipelineShaderGroups[0].generalShader = 0;
+            PipelineShaderGroups[0].closestHitShader = VK_SHADER_UNUSED_KHR;
+            PipelineShaderGroups[0].anyHitShader = VK_SHADER_UNUSED_KHR;
+            PipelineShaderGroups[0].intersectionShader = VK_SHADER_UNUSED_KHR;
+
+            PipelineShaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+            PipelineShaderStages[1].stage = VK_SHADER_STAGE_MISS_BIT_KHR;
+            PipelineShaderStages[1].module = MissShaderModule;
+            PipelineShaderStages[1].pName = "main";
+
+            PipelineShaderGroups[1].sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
+            PipelineShaderGroups[1].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
+            PipelineShaderGroups[1].generalShader = 1;
+            PipelineShaderGroups[1].closestHitShader = VK_SHADER_UNUSED_KHR;
+            PipelineShaderGroups[1].anyHitShader = VK_SHADER_UNUSED_KHR;
+            PipelineShaderGroups[1].intersectionShader = VK_SHADER_UNUSED_KHR;
+
+            PipelineShaderStages[2].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+            PipelineShaderStages[2].stage = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
+            PipelineShaderStages[2].module = HitShaderModule;
+            PipelineShaderStages[2].pName = "main";
+
+            PipelineShaderGroups[2].sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
+            PipelineShaderGroups[2].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR;
+            PipelineShaderGroups[2].generalShader = VK_SHADER_UNUSED_KHR;
+            PipelineShaderGroups[2].closestHitShader = 2;
+            PipelineShaderGroups[2].anyHitShader = VK_SHADER_UNUSED_KHR;
+            PipelineShaderGroups[2].intersectionShader = VK_SHADER_UNUSED_KHR;
+
+            VERIFY_RESULT( Vk, vkCreateRayTracingPipelinesKHR( Vk->Device, deferredOperation, VK_NULL_HANDLE, 1, &PipelineInfo, nullptr, &Pipeline ) );
+        }
+
+        [[nodiscard]]
+        inline VkDeferredOperationKHR CreatePipelineDeferred()
+        {
+            VkDeferredOperationKHR deferredOperation = VK_NULL_HANDLE;
+            VERIFY_RESULT( Vk, vkCreateDeferredOperationKHR( Vk->Device, nullptr, &deferredOperation ) );
+
+            try
+            {
+                CreatePipeline( deferredOperation );
+            }
+            catch( ... )
+            {
+                vkDestroyDeferredOperationKHR( Vk->Device, deferredOperation, nullptr );
+                throw;
+            }
+
+            return deferredOperation;
+        }
+
+        inline void JoinDeferredOperation( VkDeferredOperationKHR deferredOperation )
+        {
+            VERIFY_RESULT( Vk, vkDeferredOperationJoinKHR( Vk->Device, deferredOperation ) );
+
+            // Destroy deferred operation once it's done.
+            vkDestroyDeferredOperationKHR( Vk->Device, deferredOperation, nullptr );
+        }
+    };
+}

--- a/VkLayer_profiler_layer/profiler_tests/profiler_vulkan_state.h
+++ b/VkLayer_profiler_layer/profiler_tests/profiler_vulkan_state.h
@@ -159,7 +159,7 @@ namespace Profiler
                 vkGetPhysicalDeviceProperties( PhysicalDevice, &PhysicalDeviceProperties );
                 vkGetPhysicalDeviceMemoryProperties( PhysicalDevice, &PhysicalDeviceMemoryProperties );
             }
-            
+
             // Select graphics queue
             {
                 uint32_t queueFamilyCount = 0;
@@ -171,7 +171,7 @@ namespace Profiler
                 for( uint32_t i = 0; i < queueFamilyCount; ++i )
                 {
                     const VkQueueFamilyProperties& properties = PhysicalDeviceQueueProperties[ i ];
-                    
+
                     if( (properties.queueCount > 0) &&
                         (properties.queueFlags & VK_QUEUE_GRAPHICS_BIT) &&
                         (properties.timestampValidBits > 0) )
@@ -270,7 +270,7 @@ namespace Profiler
                 descriptorPoolCreateInfo.maxSets = 1000;
                 descriptorPoolCreateInfo.poolSizeCount = std::extent_v<decltype(descriptorPoolSizes)>;
                 descriptorPoolCreateInfo.pPoolSizes = descriptorPoolSizes;
-                
+
                 VERIFY_RESULT( this, vkCreateDescriptorPool( Device, &descriptorPoolCreateInfo, nullptr, &DescriptorPool ) );
             }
 
@@ -287,7 +287,7 @@ namespace Profiler
 
         inline void VerifyResult( VkResult result, const char* message )
         {
-            if( result != VK_SUCCESS && result != VK_INCOMPLETE )
+            if( result < 0 )
             {
                 throw VulkanError( result, message );
             }

--- a/VkLayer_profiler_layer/profiler_tests/shaders/CMakeLists.txt
+++ b/VkLayer_profiler_layer/profiler_tests/shaders/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 Lukasz Stalmirski
+# Copyright (c) 2019-2025 Lukasz Stalmirski
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -18,15 +18,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.8...3.31)
 
 project (profiler_tests_shaders)
 
 set (sources
-    "simple_triangle.vert.hlsl"
-    "simple_triangle.frag.hlsl"
+    "simple_triangle.vert.glsl"
+    "simple_triangle.frag.glsl"
+    "simple_triangle_rt.rgen.glsl"
+    "simple_triangle_rt.rchit.glsl"
+    "simple_triangle_rt.rmiss.glsl"
     )
-    
+
 set (spirvs
     )
 
@@ -36,7 +39,7 @@ foreach (source ${sources})
     string (REPLACE "." "_" var_name ${source})
     add_custom_command (
         OUTPUT ${out}
-        COMMAND ${glslangvalidator} ${in} -o ${out} -V -D -e main --vn ${var_name}
+        COMMAND ${glslangvalidator} ${in} -o ${out} -V -e main --vn ${var_name} --target-env spirv1.4
         DEPENDS ${in}
         COMMENT ${source}
         )

--- a/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle.frag.glsl
+++ b/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle.frag.glsl
@@ -1,15 +1,15 @@
-// Copyright (c) 2019-2021 Lukasz Stalmirski
-// 
+// Copyright (c) 2019-2025 Lukasz Stalmirski
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,18 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-struct VS_Out
-{
-    float4 position : SV_Position;
-    float3 color : COLOR;
-};
+#version 460 core
+layout( location = 0 ) in vec3 color;
+layout( location = 0 ) out vec4 fragColor;
 
-VS_Out main( int vertId : SV_VertexID )
+void main()
 {
-    const VS_Out triangleVertices[ 3 ] = {
-        { float4(0, -0.5, 0, 1), float3(1, 0, 0) },
-        { float4(-0.5, 0.5, 0, 1), float3(0, 0, 1) },
-        { float4(0.5, 0.5, 0, 1), float3(0, 1, 0) } };
-
-    return triangleVertices[ vertId ];
+    fragColor = vec4( color, 1 );
 }

--- a/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle.vert.glsl
+++ b/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle.vert.glsl
@@ -1,0 +1,40 @@
+// Copyright (c) 2019-2025 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#version 460 core
+layout( location = 0 ) out vec3 color;
+
+void main()
+{
+    const vec4 verts[3] = {
+        vec4( 0, -0.5, 0, 1 ),
+        vec4( -0.5, 0.5, 0, 1 ),
+        vec4( 0.5, 0.5, 0, 1 )
+    };
+
+    const vec3 colors[3] = {
+        vec3( 1, 0, 0 ),
+        vec3( 0, 0, 1 ),
+        vec3( 0, 1, 0 )
+    };
+
+    gl_Position = verts[gl_VertexIndex];
+    color = colors[gl_VertexIndex];
+}

--- a/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle_rt.rchit.glsl
+++ b/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle_rt.rchit.glsl
@@ -1,15 +1,15 @@
-// Copyright (c) 2019-2021 Lukasz Stalmirski
-// 
+// Copyright (c) 2025 Lukasz Stalmirski
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,13 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-struct PS_In
-{
-    float4 position : SV_Position;
-    float3 color : COLOR;
-};
+#version 460 core
+#extension GL_EXT_ray_tracing : enable
 
-float4 main( PS_In input ) : SV_Target
+layout( location = 0 ) rayPayloadEXT vec3 outputColor;
+
+void main()
 {
-    return float4(input.color, 1);
+    outputColor = vec3( 1.0, 0.0, 0.0 );
 }

--- a/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle_rt.rgen.glsl
+++ b/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle_rt.rgen.glsl
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#version 460 core
+#extension GL_EXT_ray_tracing : enable
+
+layout( binding = 0, set = 0 ) uniform accelerationStructureEXT accelerationStructure;
+layout( binding = 1, set = 0, rgba8 ) uniform image2D outputImage;
+layout( location = 0 ) rayPayloadEXT vec3 outputColor;
+
+void main()
+{
+    vec3 cameraPosition = vec3( 0, 0, -1 );
+    vec3 cameraDirection = vec3( 0, 0, 1 );
+
+    // compute ray direction
+    uvec2 rayIndex = gl_LaunchIDEXT.xy;
+    uvec2 dispatchSize = gl_LaunchSizeEXT.xy;
+    vec2 screenUV = ( vec2( rayIndex ) + vec2( 0.5f, 0.5f ) ) / vec2( dispatchSize.xy );
+    vec3 rayDirection = normalize( vec3( screenUV.x * 2 - 1, 1 - screenUV.y * 2, 1 ) );
+
+    // trace ray
+    outputColor = vec3( 0.0f );
+    traceRayEXT(
+        accelerationStructure,
+        gl_RayFlagsNoneEXT,
+        0xFF, 0, 0, 0,
+        cameraPosition, 0.0f,
+        rayDirection, 1e+30f, 0 );
+
+    imageStore( outputImage, ivec2( rayIndex ), vec4( outputColor, 1.0f ) );
+}

--- a/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle_rt.rmiss.glsl
+++ b/VkLayer_profiler_layer/profiler_tests/shaders/simple_triangle_rt.rmiss.glsl
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#version 460 core
+#extension GL_EXT_ray_tracing : enable
+
+layout( location = 0 ) rayPayloadEXT vec3 outputColor;
+
+void main()
+{
+    outputColor = vec3( 0.0, 0.0, 0.25 );
+}

--- a/VkLayer_profiler_layer/utils/lockable_unordered_map.h
+++ b/VkLayer_profiler_layer/utils/lockable_unordered_map.h
@@ -112,29 +112,29 @@ public:
     }
 
     // Insert new or replace existing value with a new value (thread-safe)
-    void insert_or_assign(const KeyType& key, const ValueType& value)
+    void insert_or_assign( const KeyType& key, const ValueType& value )
     {
-        std::scoped_lock lk(m_Mtx);
-        BaseType::insert_or_assign(key, value);
+        std::scoped_lock lk( m_Mtx );
+        BaseType::insert_or_assign( key, value );
     }
 
     // Insert new or replace existing value with a new value (thread-safe)
-    void insert_or_assign(const KeyType& key, ValueType&& value)
+    void insert_or_assign( const KeyType& key, ValueType&& value )
     {
-        std::scoped_lock lk(m_Mtx);
-        BaseType::insert_or_assign(key, std::move(value));
+        std::scoped_lock lk( m_Mtx );
+        BaseType::insert_or_assign( key, std::move( value ) );
     }
 
     // Insert new or replace existing value with a new value
-    void insert_or_assign_unsafe(const KeyType& key, const ValueType& value)
+    void insert_or_assign_unsafe( const KeyType& key, const ValueType& value )
     {
-        BaseType::insert_or_assign(key, value);
+        BaseType::insert_or_assign( key, value );
     }
 
     // Insert new or replace existing value with a new value
-    void insert_or_assign_unsafe(const KeyType& key, ValueType&& value)
+    void insert_or_assign_unsafe( const KeyType& key, ValueType&& value )
     {
-        BaseType::insert_or_assign(key, std::move(value));
+        BaseType::insert_or_assign( key, std::move( value ) );
     }
 
     // Remove value at key (thread-safe)

--- a/VkLayer_profiler_layer/utils/lockable_unordered_map.h
+++ b/VkLayer_profiler_layer/utils/lockable_unordered_map.h
@@ -111,6 +111,32 @@ public:
         BaseType::emplace( key, std::move( value ) );
     }
 
+    // Insert new or replace existing value with a new value (thread-safe)
+    void insert_or_assign(const KeyType& key, const ValueType& value)
+    {
+        std::scoped_lock lk(m_Mtx);
+        BaseType::insert_or_assign(key, value);
+    }
+
+    // Insert new or replace existing value with a new value (thread-safe)
+    void insert_or_assign(const KeyType& key, ValueType&& value)
+    {
+        std::scoped_lock lk(m_Mtx);
+        BaseType::insert_or_assign(key, std::move(value));
+    }
+
+    // Insert new or replace existing value with a new value
+    void insert_or_assign_unsafe(const KeyType& key, const ValueType& value)
+    {
+        BaseType::insert_or_assign(key, value);
+    }
+
+    // Insert new or replace existing value with a new value
+    void insert_or_assign_unsafe(const KeyType& key, ValueType&& value)
+    {
+        BaseType::insert_or_assign(key, std::move(value));
+    }
+
     // Remove value at key (thread-safe)
     template <typename Where>
     auto remove(Where&& where)


### PR DESCRIPTION
Use insert_or_assign instead of emplace to allow overriding existing default names with names provided by the application.