### PR TITLE
Fix mouse input on Linux.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Install Dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
-        packages: extra-cmake-modules libvulkan-dev libx11-dev libxext-dev libxrandr-dev libx11-xcb-dev libxcb-shape0-dev
+        packages: extra-cmake-modules libvulkan-dev libx11-dev libx11-xcb-dev
         version: 1.0
 
     - uses: actions/setup-python@v5

--- a/CMake/platform_linux.cmake
+++ b/CMake/platform_linux.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Lukasz Stalmirski
+# Copyright (c) 2023-2025 Lukasz Stalmirski
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,20 +27,19 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.16.0)
         set (CMAKE_MODULE_PATH ${ECM_FIND_MODULE_DIR})
 
         #find_package (Wayland)
-        find_package (XCB COMPONENTS XCB SHAPE)
-    
-        if (Wayland_FOUND OR XCB_FOUND)
+        #if (Wayland_FOUND)
+        #    set (PROFILER_PLATFORM_FOUND 1)
+        #endif ()
+
+        find_package (XCB)
+        if (XCB_FOUND)
             set (PROFILER_PLATFORM_FOUND 1)
         endif ()
     endif ()
 endif ()
 
 # If either Wayland or XCB was found, X11 is optional.
-if (NOT PROFILER_PLATFORM_FOUND)
-    set (X11_REQUIRED REQUIRED)
-endif ()
-find_package (X11 ${X11_REQUIRED})
-
+find_package (X11)
 if (X11_FOUND)
     set (PROFILER_PLATFORM_FOUND 1)
 endif ()

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Following packages are required for building on Debian-based systems:
 - g++-8.3 (or later)
 - cmake-3.8 (or later)
 - extra-cmake-modules
-- libx11-dev, libxext-dev, libxrandr-dev (for Xlib support)
-- libx11-xcb-dev, libxcb-shape0-dev (for XCB support)
+- libx11-dev (for Xlib support)
+- libx11-xcb-dev (for XCB support)
 
 To build the layer create "cmake_build" folder in the project root directory and run following command from it:
 ```

--- a/VkLayer_profiler_layer/profiler_overlay/CMakeLists.txt
+++ b/VkLayer_profiler_layer/profiler_overlay/CMakeLists.txt
@@ -127,7 +127,6 @@ if (UNIX)
 
     if (XCB_FOUND)
         target_link_libraries (profiler_overlay PRIVATE ${XCB_LIBRARIES})
-        target_link_libraries (profiler_overlay PRIVATE XCB::SHAPE)
         target_include_directories (profiler_overlay PRIVATE ${XCB_INCLUDE_DIRS})
     endif () # XCB_FOUND
 
@@ -135,9 +134,5 @@ if (UNIX)
         target_link_libraries (profiler_overlay PRIVATE ${X11_LIBRARIES} )
         target_include_directories (profiler_overlay PRIVATE ${X11_INCLUDE_DIR})
     endif () # X11_FOUND
-    if (X11_Xrandr_FOUND)
-        target_link_libraries (profiler_overlay PRIVATE ${X11_Xrandr_LIB})
-        target_include_directories (profiler_overlay PRIVATE ${X11_Xrandr_INCLUDE_PATH})
-    endif () # X11_Xrandr_FOUND
 
 endif () # UNIX

--- a/VkLayer_profiler_layer/profiler_overlay/imgui_impl_xcb.h
+++ b/VkLayer_profiler_layer/profiler_overlay/imgui_impl_xcb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Lukasz Stalmirski
+// Copyright (c) 2019-2025 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
 
 #pragma once
 #include "imgui_window.h"
-#include <vector>
 #include <xcb/xcb.h>
 #include <xcb/shape.h>
 
@@ -35,14 +34,12 @@ public:
     const char* GetName() const override;
 
     void NewFrame() override;
-    void AddInputCaptureRect( int x, int y, int width, int height ) override;
 
 private:
     ImGuiContext* m_pImGuiContext;
     xcb_connection_t* m_Connection;
     xcb_window_t m_AppWindow;
     xcb_window_t m_InputWindow;
-    std::vector<xcb_rectangle_t> m_InputRects;
 
     xcb_get_geometry_reply_t GetGeometry( xcb_drawable_t );
 

--- a/VkLayer_profiler_layer/profiler_overlay/imgui_impl_xlib.h
+++ b/VkLayer_profiler_layer/profiler_overlay/imgui_impl_xlib.h
@@ -20,9 +20,7 @@
 
 #pragma once
 #include "imgui_window.h"
-#include <vector>
 #include <X11/Xlib.h>
-#include <X11/extensions/shape.h>
 
 struct ImGuiContext;
 
@@ -35,15 +33,12 @@ public:
     const char* GetName() const override;
 
     void NewFrame() override;
-    void AddInputCaptureRect( int x, int y, int width, int height ) override;
 
 private:
     ImGuiContext* m_pImGuiContext;
     Display* m_Display;
-    XIM m_IM;
     Window m_AppWindow;
     Window m_InputWindow;
-    std::vector<XRectangle> m_InputRects;
 
     void UpdateMousePos();
 };

--- a/VkLayer_profiler_layer/profiler_overlay/imgui_window.h
+++ b/VkLayer_profiler_layer/profiler_overlay/imgui_window.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Lukasz Stalmirski
+// Copyright (c) 2019-2025 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,5 @@ public:
     virtual ~ImGui_Window_Context() {}
     virtual const char* GetName() const = 0;
     virtual void NewFrame() = 0;
-    virtual void AddInputCaptureRect( int x, int y, int width, int height ) {}
     virtual float GetDPIScale() const { return 1.0f; }
 };

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -1039,15 +1039,6 @@ namespace Profiler
         ImGui::PushFont( m_Resources.GetDefaultFont() );
         ImGui::Begin( m_Title.c_str(), nullptr, ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_MenuBar );
 
-        // Update input clipping rect
-        ImVec2 pos = ImGui::GetWindowPos();
-        ImVec2 size = ImGui::GetWindowSize();
-        m_pImGuiWindowContext->AddInputCaptureRect(
-            static_cast<int>(pos.x),
-            static_cast<int>(pos.y),
-            static_cast<int>(size.x),
-            static_cast<int>(size.y) );
-
         if( ImGui::BeginMenuBar() )
         {
             if( ImGui::BeginMenu( Lang::FileMenu ) )
@@ -1147,18 +1138,6 @@ namespace Profiler
                     state.Docked = ImGui::IsWindowDocked() &&
                         (dockSpaceId == m_MainDockSpaceId ||
                             dockSpaceId == m_PerformanceTabDockSpaceId);
-                    
-                    if( !state.Docked )
-                    {
-                        // Add input clipping rect for this window
-                        ImVec2 pos = ImGui::GetWindowPos();
-                        ImVec2 size = ImGui::GetWindowSize();
-                        m_pImGuiWindowContext->AddInputCaptureRect(
-                            static_cast<int>(pos.x),
-                            static_cast<int>(pos.y),
-                            static_cast<int>(size.x),
-                            static_cast<int>(size.y) );
-                    }
 
                     state.Focus = false;
                 }


### PR DESCRIPTION
Remove dependency on X11 shape extensions. Instead, receive all events from the input window and forward them to the parent window if not captured by the ImGui.