### PR TITLE
Jump to selected command buffer from the queue graph.

### DIFF
--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
@@ -282,6 +282,8 @@ namespace Profiler
         struct QueueGraphColumn;
         void GetQueueGraphColumns( VkQueue, std::vector<QueueGraphColumn>& ) const;
         float GetQueueUtilization( const std::vector<QueueGraphColumn>& ) const;
+        void DrawQueueGraphLabel( const ImGuiX::HistogramColumnData& );
+        void SelectQueueGraphColumn( const ImGuiX::HistogramColumnData& );
 
         // Performance counter helpers
         std::string GetDefaultPerformanceCountersFileName( uint32_t ) const;


### PR DESCRIPTION
Clicking on a command buffer in the queue graph will now scroll to that command buffer in the frame browser. Queue graph tooltips will now show command buffer name and duration.