### PR TITLE
Fix performance graph mouse events.

### DIFF
--- a/VkLayer_profiler_layer/profiler_overlay/imgui_widgets/imgui_histogram_ex.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/imgui_widgets/imgui_histogram_ex.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Lukasz Stalmirski
+// Copyright (c) 2019-2025 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -93,6 +93,50 @@ namespace ImGuiX
 
     /*************************************************************************\
 
+    Function:
+        IsMouseHoveringWindow
+
+    \*************************************************************************/
+    bool IsMouseHoveringWindow( ImGuiWindow* window )
+    {
+        auto IsMouseHoveringWindowImpl = []( ImGuiWindow* w ) {
+            bool is_mouse_over = false;
+            if( w && w->WasActive && !w->SkipItems )
+            {
+                ImRect rc = w->Rect();
+                is_mouse_over =
+                    rc.ContainsWithPad( GImGui->IO.MousePos, GImGui->Style.TouchExtraPadding );
+            }
+            return is_mouse_over;
+        };
+
+        // Check if any modal window is open
+        ImGuiWindow* modal_window = GetTopMostPopupModal();
+        if( modal_window && ( modal_window != window ) )
+            return false;
+
+        // Check if the cursor is over the current window
+        if( !IsMouseHoveringWindowImpl( window ) )
+            return false;
+
+        // Check if the cursor is over any other window above the current one
+        ImGuiWindow** next_window = GImGui->Windows.Data;
+        ImGuiWindow** last_window = GImGui->Windows.Data + GImGui->Windows.Size;
+        while( next_window != last_window && *next_window != window )
+            next_window++;
+
+        while( next_window != last_window )
+        {
+            if( ( *next_window != window ) && IsMouseHoveringWindowImpl( *next_window ) )
+                return false;
+            next_window++;
+        }
+
+        return true;
+    }
+
+    /*************************************************************************\
+
         PlotHistogramEx
 
     \*************************************************************************/
@@ -116,6 +160,9 @@ namespace ImGuiX
         ImGuiWindow* window = GetCurrentWindow();
         if( window->SkipItems )
             return;
+
+        // Check if cursor is above the current window
+        const bool mouse_over_window = IsMouseHoveringWindow( window );
 
         const ImGuiStyle& style = g.Style;
         const ImGuiID id = window->GetID( label );
@@ -200,13 +247,14 @@ namespace ImGuiX
                     { x_pos + 5.0f * g.IO.FontGlobalScale, y_pos + 5.0f * g.IO.FontGlobalScale } );
 
                 const bool event_hovered =
+                    ( mouse_over_window ) &&
                     ( flags & HistogramFlags_NoHover ) == 0 &&
                     ( data.flags & HistogramColumnFlags_NoHover ) == 0 &&
-                    event_bb.Contains( g.IO.MousePos );
+                    event_bb.ContainsWithPad( g.IO.MousePos, style.TouchExtraPadding );
 
                 if( event_hovered )
                 {
-                    if( click_cb && IsMouseClicked( ImGuiMouseButton_Left ) )
+                    if( click_cb && IsMouseClicked( ImGuiMouseButton_Left, 0, ImGuiKeyOwner_NoOwner ) )
                     {
                         click_cb( data );
                     }
@@ -236,9 +284,10 @@ namespace ImGuiX
 
                 const ImRect column_bb( { x_pos, y_pos }, { x_pos + column_width, inner_bb.Max.y } );
                 const bool hovered_column =
+                    ( mouse_over_window ) &&
                     ( flags & HistogramFlags_NoHover ) == 0 &&
                     ( data.flags & HistogramColumnFlags_NoHover ) == 0 &&
-                    column_bb.Contains( g.IO.MousePos );
+                    column_bb.ContainsWithPad( g.IO.MousePos, style.TouchExtraPadding );
 
                 window->DrawList->AddRectFilled(
                     column_bb.Min,
@@ -247,7 +296,7 @@ namespace ImGuiX
 
                 if( hovered_column )
                 {
-                    if( click_cb && IsMouseClicked( ImGuiMouseButton_Left ) )
+                    if( click_cb && IsMouseClicked( ImGuiMouseButton_Left, 0, ImGuiKeyOwner_NoOwner ) )
                     {
                         click_cb( data );
                     }


### PR DESCRIPTION
Closing a combo box or a modal window displayed on top of the performance graph should not trigger a mouse click in the graph if the cursor is over it.