### PR TITLE
Fix traces collected in per-submit mode.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -1441,6 +1441,7 @@ namespace Profiler
         frame.m_ThreadId = ProfilerPlatformFunctions::GetCurrentThreadId();
         frame.m_Timestamp = m_CpuTimestampCounter.GetCurrentValue();
         frame.m_FramesPerSec = m_CpuFpsCounter.GetValue();
+        frame.m_SyncMode = static_cast<VkProfilerSyncModeEXT>( m_Config.m_SyncMode.value );
         frame.m_SyncTimestamps = m_Synchronization.GetSynchronizationTimestamps();
 
         m_DataAggregator.AppendFrame( frame );

--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -1294,19 +1294,14 @@ namespace Profiler
             ReleasePerformanceConfigurationINTEL();
         }
 
+        // Append the submit batch for aggregation
+        m_DataAggregator.AppendSubmit( submitBatch );
+
         if( m_Config.m_SyncMode == sync_mode_t::submit )
         {
             // Begin the next frame
             BeginNextFrame();
         }
-
-        if( !m_DataAggregator.IsDataCollectionThreadRunning() )
-        {
-            m_DataAggregator.Aggregate();
-        }
-
-        // Append the submit batch for aggregation
-        m_DataAggregator.AppendSubmit( submitBatch );
 
         // Get data captured during the last frame
         ResolveFrameData( tip );
@@ -1423,12 +1418,6 @@ namespace Profiler
             BeginNextFrame();
         }
 
-        if( !m_DataAggregator.IsDataCollectionThreadRunning() )
-        {
-            // Collect data from the submitted command buffers
-            m_DataAggregator.Aggregate();
-        }
-
         // Get data captured during the last frame
         ResolveFrameData( tip );
     }
@@ -1467,16 +1456,21 @@ namespace Profiler
     \***********************************************************************************/
     void DeviceProfiler::ResolveFrameData( TipRangeId& tip )
     {
-        std::list<std::shared_ptr<DeviceProfilerFrameData>> pResolvedData =
-            m_DataAggregator.GetAggregatedData();
+        if( !m_DataAggregator.IsDataCollectionThreadRunning() )
+        {
+            // Collect data from the submitted command buffers
+            m_DataAggregator.Aggregate();
+        }
+
+        m_pDevice->TIP.EndFunction( tip );
 
         // Check if new data is available
+        auto pResolvedData = m_DataAggregator.GetAggregatedData();
         if( !pResolvedData.empty() )
         {
             m_pData.insert( m_pData.end(), pResolvedData.begin(), pResolvedData.end() );
 
             // Return TIP data
-            m_pDevice->TIP.EndFunction( tip );
             m_pData.back()->m_TIP = m_pDevice->TIP.GetData();
 
             // Free frames above the buffer size

--- a/VkLayer_profiler_layer/profiler/profiler_data.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data.h
@@ -1379,6 +1379,8 @@ namespace Profiler
         uint64_t                                            m_BeginTimestamp = {};
         uint64_t                                            m_EndTimestamp = {};
 
+        VkProfilerSyncModeEXT                               m_SyncMode = {};
+
         DeviceProfilerMemoryData                            m_Memory = {};
         DeviceProfilerCPUData                               m_CPU = {};
         std::vector<struct TipRange>                        m_TIP = {};

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
@@ -537,6 +537,8 @@ namespace Profiler
         frameData.m_BeginTimestamp = std::numeric_limits<uint64_t>::max();
         frameData.m_EndTimestamp = 0;
 
+        frameData.m_SyncMode = frame.m_SyncMode;
+
         // Collect per-frame stats
         for( const auto& submitBatch : frame.m_CompleteSubmits )
         {

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
@@ -57,6 +57,7 @@ namespace Profiler
         uint32_t                                        m_ThreadId = 0;
         uint64_t                                        m_Timestamp = 0;
         float                                           m_FramesPerSec = 0;
+        VkProfilerSyncModeEXT                           m_SyncMode = {};
         DeviceProfilerSynchronizationTimestamps         m_SyncTimestamps = {};
     };
 

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Lukasz Stalmirski
+// Copyright (c) 2019-2025 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -179,12 +179,15 @@ namespace Profiler
             }
         }
 
-        // Insert present event
-        m_pEvents.push_back( new ApiTraceEvent(
-            TraceEvent::Phase::eInstant,
-            "vkQueuePresentKHR",
-            data.m_CPU.m_ThreadId,
-            GetNormalizedCpuTimestamp( data.m_CPU.m_EndTimestamp ) ) );
+        if( data.m_SyncMode == VK_PROFILER_SYNC_MODE_PRESENT_EXT )
+        {
+            // Insert present event
+            m_pEvents.push_back( new ApiTraceEvent(
+                TraceEvent::Phase::eInstant,
+                "vkQueuePresentKHR",
+                data.m_CPU.m_ThreadId,
+                GetNormalizedCpuTimestamp( data.m_CPU.m_EndTimestamp ) ) );
+        }
 
         // Insert TIP events
         Serialize( data.m_TIP );


### PR DESCRIPTION
Send synchronization timestamps before the submission to avoid integer overflows and don't insert vkQueuePresentKHR events in per-submit traces.