### PR TITLE
Fix VK_KHR_get_physical_device_properties2 extension enabling.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -67,7 +67,7 @@ namespace Profiler
         DeviceProfiler();
 
         static void SetupDeviceCreateInfo( VkPhysicalDevice_Object&, const ProfilerLayerSettings&, std::unordered_set<std::string>&, PNextChain& );
-        static void SetupInstanceCreateInfo( std::unordered_set<std::string>& );
+        static void SetupInstanceCreateInfo( const VkInstanceCreateInfo&, PFN_vkGetInstanceProcAddr, std::unordered_set<std::string>& );
 
         static void LoadConfiguration( const ProfilerLayerSettings&, const VkProfilerCreateInfoEXT*, DeviceProfilerConfig* );
 


### PR DESCRIPTION
The extension is an instance extension, so it should be checked and implicitly enabled during instance creation.