### PR TITLE
Keep overlay state when swapchain is recreated.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -374,7 +374,9 @@ namespace Profiler
     VkResult DeviceProfiler::Initialize( VkDevice_Object* pDevice, const VkDeviceCreateInfo* pCreateInfo )
     {
         m_pDevice = pDevice;
-        m_NextFrameIndex = 0;
+
+        // Frame #0 is allocated by the aggregator.
+        m_NextFrameIndex = 1;
 
         // Check if profiler create info was provided.
         const PNextChain pNextChain( pCreateInfo->pNext );

--- a/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkSwapchainKhr_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkSwapchainKhr_functions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Lukasz Stalmirski
+// Copyright (c) 2019-2025 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -78,12 +78,6 @@ namespace Profiler
 
         if( createProfilerOverlay )
         {
-            if( dd.pOutput )
-            {
-                // Destroy the previous output before creating an overlay
-                dd.pOutput->Destroy();
-            }
-
             if( result == VK_SUCCESS && !dd.OverlayBackend.IsInitialized() )
             {
                 // Initialize overlay backend
@@ -110,15 +104,14 @@ namespace Profiler
                     &dd.pOutput,
                     dd.ProfilerFrontend,
                     dd.OverlayBackend );
-            }
 
-            if( result == VK_SUCCESS )
-            {
-                // Initialize the overlay output
-                bool success = dd.pOutput->Initialize();
-                if( !success )
+                if( result == VK_SUCCESS )
                 {
-                    result = VK_ERROR_INITIALIZATION_FAILED;
+                    bool success = dd.pOutput->Initialize();
+                    if( !success )
+                    {
+                        result = VK_ERROR_INITIALIZATION_FAILED;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Reset only swapchain-specific members when the swapchain is recreated and preserve all other data and state.