### PR TITLE
Merge adjacent sparse memory bindings.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_memory_tracker.h
+++ b/VkLayer_profiler_layer/profiler/profiler_memory_tracker.h
@@ -73,5 +73,7 @@ namespace Profiler
         ConcurrentMap<VkObjectHandle<VkImage>, DeviceProfilerImageMemoryData> m_Images;
 
         void ResetMemoryData();
+
+        void UnbindBufferMemoryRange( std::vector<DeviceProfilerBufferMemoryBindingData>& bindings, VkDeviceSize offset, VkDeviceSize size );
     };
 }


### PR DESCRIPTION
Treat multiple continuous bindings to the same memory as a single binding for better readability.