### PR TITLE
Fix crash on vkDestroyDevice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿# Copyright (c) 2019-2024 Lukasz Stalmirski
+﻿# Copyright (c) 2019-2025 Lukasz Stalmirski
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,7 @@ option (BUILD_SPIRV_DOCS "Build SPIR-V documentation into the disassembly view."
 set    (SPIRV_DOCS_URL "https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html"
             CACHE STRING "URL of the SPIR-V documentation page.")
 option (SKIP_PLATFORMS_CHECK "Skip checking for Vulkan platform support." OFF)
+option (PROFILER_ENABLE_TIP "Enable time-in-profiler instrumentation." OFF)
 
 # Vulkan platform support.
 include (CMake/platform.cmake NO_POLICY_SCOPE)

--- a/VkLayer_profiler_layer/CMakeLists.txt
+++ b/VkLayer_profiler_layer/CMakeLists.txt
@@ -90,11 +90,11 @@ configure_file (
     "${CMAKE_CURRENT_SOURCE_DIR}/${PROFILER_LAYER_PROJECTNAME}.json.in"
     "${json}_configured"
     @ONLY)
-    
+
 file (GENERATE
     OUTPUT "${json}"
     INPUT "${json}_configured")
-    
+
 add_custom_command (
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/vk_layer_config.h"
     COMMAND "${Python3_EXECUTABLE}"
@@ -174,6 +174,11 @@ target_compile_definitions (profiler_common INTERFACE
     $<$<CONFIG:Release>:PROFILER_CONFIG_RELEASE>
     $<$<CONFIG:MinSizeRel>:PROFILER_CONFIG_MINSIZEREL>)
 add_dependencies (profiler_common profiler_codegen)
+
+if (PROFILER_ENABLE_TIP)
+    target_compile_definitions (profiler_common INTERFACE
+        PROFILER_ENABLE_TIP=1)
+endif ()
 
 if (BUILD_SPIRV_DOCS)
     target_compile_definitions (profiler_common INTERFACE

--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -524,6 +524,9 @@ namespace Profiler
     {
         TipRangeId tip = m_pDevice->TIP.BeginFunction( __func__ );
 
+        // Data aggregator may run in background so it must be stopped first.
+        m_DataAggregator.StopDataCollectionThread();
+
         // Begin a fake frame at the end to allow finalization of the last submitted frame.
         BeginNextFrame();
         ResolveFrameData( tip );

--- a/VkLayer_profiler_layer/profiler/profiler_counters.h
+++ b/VkLayer_profiler_layer/profiler/profiler_counters.h
@@ -35,13 +35,9 @@
 #include "profiler_counters_linux.inl"
 #endif
 
-// Enable time in profiler counters in non-release builds
+// Disable time-in-profiler instrumentation unless requested in the configuration
 #ifndef PROFILER_ENABLE_TIP
-#if defined( PROFILER_CONFIG_DEBUG ) || defined( PROFILER_CONFIG_RELWITHDEBINFO )
-#define PROFILER_ENABLE_TIP 1
-#else
 #define PROFILER_ENABLE_TIP 0
-#endif
 #endif // PROFILER_ENABLE_TIP
 
 namespace Profiler

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
@@ -215,15 +215,29 @@ namespace Profiler
     \***********************************************************************************/
     void ProfilerDataAggregator::Destroy()
     {
-        if( m_DataCollectionThreadRunning )
-        {
-            assert( m_DataCollectionThread.joinable() );
-            m_DataCollectionThreadRunning = false;
-            m_DataCollectionThread.join();
-        }
+        StopDataCollectionThread();
 
         m_CopyCommandPools.clear();
         m_pProfiler = nullptr;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        StopDataCollectionThread
+
+    Description:
+
+    \***********************************************************************************/
+    void ProfilerDataAggregator::StopDataCollectionThread()
+    {
+        m_DataCollectionThreadRunning = false;
+
+        if( m_DataCollectionThread.joinable() )
+        {
+            m_DataCollectionThread.join();
+            m_DataCollectionThread = std::thread();
+        }
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
@@ -109,6 +109,7 @@ namespace Profiler
         void SetDataBufferSize( uint32_t maxFrames );
 
         bool IsDataCollectionThreadRunning() const { return m_DataCollectionThreadRunning; }
+        void StopDataCollectionThread();
 
         void AppendFrame( const DeviceProfilerFrame& );
         void AppendSubmit( const DeviceProfilerSubmitBatch& );


### PR DESCRIPTION
Stop data collection background thread before resetting any of the other profiler states.