### PR TITLE
Implement missing layer interface functions.

### DIFF
--- a/VkLayer_profiler_layer/CMakeLists.txt
+++ b/VkLayer_profiler_layer/CMakeLists.txt
@@ -325,6 +325,11 @@ add_library (${PROFILER_LAYER_PROJECTNAME} SHARED
     "VkLayer_profiler_layer.def"
     ${resource})
 
+if (UNIX AND NOT APPLE)
+    target_link_options(${PROFILER_LAYER_PROJECTNAME}
+        PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_profiler_layer.map)
+endif ()
+
 # Link against implementation
 target_link_libraries (${PROFILER_LAYER_PROJECTNAME}_lib
     PUBLIC profiler

--- a/VkLayer_profiler_layer/VkLayer_profiler_layer.cpp
+++ b/VkLayer_profiler_layer/VkLayer_profiler_layer.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2021 Lukasz Stalmirski
+﻿// Copyright (c) 2019-2025 Lukasz Stalmirski
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,16 +23,25 @@
 #include "profiler_layer_functions/core/VkDevice_functions.h"
 #include <vulkan/vk_layer.h>
 
+// clang-format off
 #undef VK_LAYER_EXPORT
-#if defined( _MSC_VER )
-#   define VK_LAYER_EXPORT extern "C"
-#elif defined( __GNUC__ ) && __GNUC__ >= 4
-#   define VK_LAYER_EXPORT extern "C" __attribute__((visibility("default")))
-#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
-#   define VK_LAYER_EXPORT extern "C" __attribute__((visibility("default")))
+#if (defined(__GNUC__) && (__GNUC__ >= 4)) || \
+    (defined(__clang__)) || \
+    (defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590))
+#  define VK_LAYER_EXPORT extern "C" __attribute__((visibility("default")))
 #else
-#   define VK_LAYER_EXPORT extern "C"
+// MSVC compiler uses def file for export definitions.
+#  define VK_LAYER_EXPORT extern "C"
 #endif
+// clang-format on
+
+static VkResult CheckResult( VkResult result )
+{
+    // Exported interface functions must never fail.
+    // All error codes are negative.
+    assert( result >= VK_SUCCESS );
+    return result;
+}
 
 /***************************************************************************************\
 
@@ -40,10 +49,11 @@ Function:
     vkGetInstanceProcAddr
 
 Description:
-    Entrypoint to the VkInstance
+    Entrypoint to the VkInstance.
+    Required by layer interface version 0 and 1.
 
 \***************************************************************************************/
-VK_LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(
     VkInstance instance,
     const char* name )
 {
@@ -56,14 +66,136 @@ Function:
     vkGetDeviceProcAddr
 
 Description:
-    Entrypoint to the VkDevice
+    Entrypoint to the VkDevice.
+    Required by layer interface version 0 and 1.
 
 \***************************************************************************************/
-VK_LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(
     VkDevice device,
     const char* name )
 {
     return Profiler::VkDevice_Functions::GetDeviceProcAddr( device, name );
+}
+
+/***************************************************************************************\
+
+Function:
+    vkEnumerateInstanceLayerProperties
+
+Description:
+    Entrypoint to the EnumerateInstanceLayerProperties.
+    Required by layer interface version 0.
+
+\***************************************************************************************/
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
+    uint32_t* pPropertyCount,
+    VkLayerProperties* pProperties )
+{
+    return CheckResult( Profiler::VkInstance_Functions::EnumerateInstanceLayerProperties(
+        pPropertyCount,
+        pProperties ) );
+}
+
+/***************************************************************************************\
+
+Function:
+    vkEnumerateInstanceExtensionProperties
+
+Description:
+    Entrypoint to the EnumerateInstanceExtensionProperties.
+    Required by layer interface version 0.
+
+\***************************************************************************************/
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(
+    const char* pLayerName,
+    uint32_t* pPropertyCount,
+    VkExtensionProperties* pProperties )
+{
+    assert( pLayerName && ( strcmp( pLayerName, VK_LAYER_profiler_name ) == 0 ) );
+    return CheckResult( Profiler::VkInstance_Functions::EnumerateInstanceExtensionProperties(
+        pLayerName,
+        pPropertyCount,
+        pProperties ) );
+}
+
+/***************************************************************************************\
+
+Function:
+    vkEnumerateDeviceLayerProperties
+
+Description:
+    Entrypoint to the EnumerateDeviceLayerProperties.
+    Required by layer interface version 0.
+
+\***************************************************************************************/
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(
+    VkPhysicalDevice physicalDevice,
+    uint32_t* pPropertyCount,
+    VkLayerProperties* pProperties )
+{
+    assert( physicalDevice == VK_NULL_HANDLE );
+    return CheckResult( Profiler::VkInstance_Functions::EnumerateDeviceLayerProperties(
+        VK_NULL_HANDLE,
+        pPropertyCount,
+        pProperties ) );
+}
+
+/***************************************************************************************\
+
+Function:
+    vkEnumerateDeviceExtensionProperties
+
+Description:
+    Entrypoint to the EnumerateDeviceExtensionProperties.
+    Required by layer interface version 0.
+
+\***************************************************************************************/
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(
+    VkPhysicalDevice physicalDevice,
+    const char* pLayerName,
+    uint32_t* pPropertyCount,
+    VkExtensionProperties* pProperties )
+{
+    assert( physicalDevice == VK_NULL_HANDLE );
+    assert( pLayerName && ( strcmp( pLayerName, VK_LAYER_profiler_name ) == 0 ) );
+    return CheckResult( Profiler::VkInstance_Functions::EnumerateDeviceExtensionProperties(
+        VK_NULL_HANDLE,
+        pLayerName,
+        pPropertyCount,
+        pProperties ) );
+}
+
+/***************************************************************************************\
+
+Function:
+    vkNegotiateLoaderLayerInterfaceVersion
+
+Description:
+    Entrypoint to the layer interface version negotiation.
+    Required by layer interface version 2.
+
+\***************************************************************************************/
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVersion(
+    VkNegotiateLayerInterface* pVersionStruct )
+{
+    if( pVersionStruct == nullptr ||
+        pVersionStruct->sType != LAYER_NEGOTIATE_INTERFACE_STRUCT )
+    {
+        // Invalid or unsupported structure.
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    // The layer currently supports version 2 of the interface.
+    // According to the spec no loader should report a version lower than 2 (as this is the version that introduced this function).
+    assert( pVersionStruct->loaderLayerInterfaceVersion >= 2 );
+    pVersionStruct->loaderLayerInterfaceVersion = 2;
+
+    // Fill function pointers.
+    pVersionStruct->pfnGetInstanceProcAddr = Profiler::VkInstance_Functions::GetInstanceProcAddr;
+    pVersionStruct->pfnGetDeviceProcAddr = Profiler::VkDevice_Functions::GetDeviceProcAddr;
+    pVersionStruct->pfnGetPhysicalDeviceProcAddr = nullptr;
+
+    return VK_SUCCESS;
 }
 
 #ifdef WIN32

--- a/VkLayer_profiler_layer/VkLayer_profiler_layer.def
+++ b/VkLayer_profiler_layer/VkLayer_profiler_layer.def
@@ -1,4 +1,4 @@
-; Copyright (c) 2019-2021 Lukasz Stalmirski
+; Copyright (c) 2019-2025 Lukasz Stalmirski
 ; 
 ; Permission is hereby granted, free of charge, to any person obtaining a copy
 ; of this software and associated documentation files (the "Software"), to deal
@@ -22,3 +22,8 @@ LIBRARY VkLayer_profiler_layer
 EXPORTS
   vkGetInstanceProcAddr
   vkGetDeviceProcAddr
+  vkEnumerateInstanceLayerProperties
+  vkEnumerateInstanceExtensionProperties
+  vkEnumerateDeviceLayerProperties
+  vkEnumerateDeviceExtensionProperties
+  vkNegotiateLoaderLayerInterfaceVersion

--- a/VkLayer_profiler_layer/VkLayer_profiler_layer.map
+++ b/VkLayer_profiler_layer/VkLayer_profiler_layer.map
@@ -1,0 +1,12 @@
+{
+  global:
+    vkGetInstanceProcAddr;
+    vkGetDeviceProcAddr;
+    vkEnumerateInstanceLayerProperties;
+    vkEnumerateInstanceExtensionProperties;
+    vkEnumerateDeviceLayerProperties;
+    vkEnumerateDeviceExtensionProperties;
+    vkNegotiateLoaderLayerInterfaceVersion;
+  local:
+    *;
+};

--- a/VkLayer_profiler_layer/profiler_ext/VkProfilerEXT.h
+++ b/VkLayer_profiler_layer/profiler_ext/VkProfilerEXT.h
@@ -21,6 +21,10 @@
 #pragma once
 #include <vulkan/vulkan.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef VK_EXT_profiler
 #define VK_EXT_profiler 1
 #define VK_EXT_PROFILER_SPEC_VERSION 5
@@ -418,3 +422,7 @@ VKAPI_ATTR void VKAPI_CALL vkGetProfilerActivePerformanceMetricsSetIndexEXT(
     uint32_t* pMetricsSetIndex );
 #endif // VK_NO_PROTOTYPES
 #endif // VK_EXT_profiler
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/VkLayer_profiler_layer/profiler_ext/VkProfilerObjectEXT.h
+++ b/VkLayer_profiler_layer/profiler_ext/VkProfilerObjectEXT.h
@@ -21,6 +21,10 @@
 #pragma once
 #include <vulkan/vulkan.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef VK_EXT_profiler_object
 #define VK_EXT_profiler_object 1
 #define VK_EXT_PROFILER_OBJECT_SPEC_VERSION 1
@@ -42,3 +46,7 @@ VKAPI_ATTR void VKAPI_CALL vkGetProfilerOverlayEXT(
     VkProfilerOverlayEXT* pOverlay );
 #endif // VK_NO_PROTOTYPES
 #endif // VK_EXT_profiler_object
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkPhysicalDevice_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkPhysicalDevice_functions.cpp
@@ -186,13 +186,9 @@ namespace Profiler
         VkExtensionProperties* pProperties )
     {
         const bool queryThisLayerExtensionsOnly =
-            (pLayerName) &&
-            (strcmp( pLayerName, VK_LAYER_profiler_name ) != 0);
-
-        // EnumerateDeviceExtensionProperties is actually VkInstance (VkPhysicalDevice) function.
-        // Get dispatch table associated with the VkPhysicalDevice and invoke next layer's
-        // vkEnumerateDeviceExtensionProperties implementation.
-        auto& id = InstanceDispatch.Get( physicalDevice );
+            (physicalDevice == VK_NULL_HANDLE) ||
+            ((pLayerName) &&
+             (strcmp( pLayerName, VK_LAYER_profiler_name ) != 0));
 
         VkResult result = VK_SUCCESS;
 
@@ -201,6 +197,10 @@ namespace Profiler
 
         if( !pLayerName || !queryThisLayerExtensionsOnly )
         {
+            // EnumerateDeviceExtensionProperties is actually VkInstance (VkPhysicalDevice) function.
+            // Get dispatch table associated with the VkPhysicalDevice and invoke next layer's
+            // vkEnumerateDeviceExtensionProperties implementation.
+            auto& id = InstanceDispatch.Get( physicalDevice );
             result = id.Instance.Callbacks.EnumerateDeviceExtensionProperties(
                 physicalDevice, pLayerName, pPropertyCount, pProperties );
         }


### PR DESCRIPTION
Add missing functions from layer interface v0 and v2:
- vkEnumerateInstanceLayerProperties
- vkEnumerateInstanceExtensionProperties
- vkEnumerateDeviceLayerProperties
- vkEnumerateDeviceExtensionProperties
- vkNegotiateLoaderLayerInterfaceVersion