### PR TITLE
Reduce thread synchronization during frame data processing.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
@@ -131,7 +131,6 @@ namespace Profiler
         , m_pResolvedFrames()
         , m_pPendingFrames()
         , m_Mutex()
-        , m_FrameResolveMutex()
         , m_FrameIndex( 0 )
         , m_MaxResolvedFrameCount( 1 )
         , m_CopyCommandPools()

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
@@ -24,7 +24,6 @@
 #include "profiler_command_pool.h"
 #include <list>
 #include <vector>
-#include <mutex>
 #include <shared_mutex>
 #include <thread>
 #include <unordered_set>
@@ -128,7 +127,6 @@ namespace Profiler
         std::list<std::shared_ptr<Frame>> m_pPendingFrames;
 
         std::shared_mutex m_Mutex;
-        std::mutex m_FrameResolveMutex;
         uint32_t m_FrameIndex;
 
         uint32_t m_MaxResolvedFrameCount;


### PR DESCRIPTION
Release lock when processing frame data to avoid blocking application threads from recording next frames.