### PR TITLE
Apply range selection to the performance counters stream.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
@@ -138,7 +138,8 @@ namespace Profiler
 
         void LoadPerformanceMetricsProperties( uint32_t, std::vector<VkProfilerPerformanceCounterProperties2EXT>& ) const;
         void CollectPerformanceMetricsStreamData( uint64_t, uint64_t, DeviceProfilerPerformanceCountersData& ) const;
-        void AggregatePerformanceMetrics( const Frame&, DeviceProfilerPerformanceCountersData& ) const;
+        void AggregatePerformanceQueryMetrics( ContainerType<DeviceProfilerSubmitBatchData>&, DeviceProfilerPerformanceCountersData& ) const;
+        void AggregatePerformanceStreamMetrics( ContainerType<DeviceProfilerSubmitBatchData>&, DeviceProfilerPerformanceCountersData& ) const;
 
         ContainerType<DeviceProfilerPipelineData> CollectTopPipelines( const Frame& ) const;
         void CollectPipelinesFromCommandBuffer( const DeviceProfilerCommandBufferData&, std::unordered_map<uint32_t, DeviceProfilerPipelineData>& ) const;

--- a/VkLayer_profiler_layer/profiler/profiler_performance_counters_intel.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_performance_counters_intel.cpp
@@ -843,7 +843,8 @@ namespace Profiler
             // Adjust timestamps to be relative to the begin timestamp.
             for( auto it = begin; it != end; ++it )
             {
-                it->m_GpuTimestamp -= beginTimestampNs;
+                it->m_GpuTimestamp = beginTimestamp +
+                    ConvertNanosecondsToGpuTimestamp( it->m_GpuTimestamp - beginTimestampNs );
             }
 
             // Copy the data to the output buffer.
@@ -1009,6 +1010,19 @@ namespace Profiler
         const double gpuTimestampNsLow = ( gpuTimestamp & scGpuTimestampMask32Bits ) * m_GpuTimestampPeriod;
 
         return ( static_cast<uint64_t>( gpuTimestampNsHigh ) << 32 ) + static_cast<uint64_t>( gpuTimestampNsLow + gpuTimestampNsHighFractionalPart );
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        ConvertGpuTimestampToNanoseconds
+
+    Description:
+
+    \***********************************************************************************/
+    uint64_t DeviceProfilerPerformanceCountersINTEL::ConvertNanosecondsToGpuTimestamp( uint64_t nanoseconds )
+    {
+        return static_cast<uint64_t>( nanoseconds / m_GpuTimestampQueryPeriod );
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler_performance_counters_intel.h
+++ b/VkLayer_profiler_layer/profiler/profiler_performance_counters_intel.h
@@ -180,6 +180,7 @@ namespace Profiler
             ReportInformations* pReportInformations );
 
         uint64_t ConvertGpuTimestampToNanoseconds( uint64_t gpuTimestamp );
+        uint64_t ConvertNanosecondsToGpuTimestamp( uint64_t nanoseconds );
 
         void ResetMembers();
 

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
@@ -298,6 +298,13 @@ namespace Profiler
         // Performance metrics filter.
         // The profiler will show only metrics for the selected command buffer.
         // If no command buffer is selected, the aggregated stats for the whole frame will be displayed.
+        struct PerformanceQueryRangeData
+        {
+            const DeviceProfilerPerformanceCountersData* m_pPerformanceCountersData;
+            uint64_t m_BeginTimestamp;
+            uint64_t m_EndTimestamp;
+        };
+
         VkCommandBufferHandle m_PerformanceQueryCommandBufferFilter;
         std::string m_PerformanceQueryCommandBufferFilterName;
 
@@ -419,8 +426,8 @@ namespace Profiler
         void UpdatePerformanceQueryMetricsSetExporter();
         void SavePerformanceQueryMetricsSetToFile( const std::string&, const std::shared_ptr<PerformanceQueryMetricsSet>& );
 
-        void DrawPerformanceCountersQueryData( const std::vector<VkProfilerPerformanceCounterResultEXT>& );
-        void DrawPerformanceCountersStreamData();
+        void DrawPerformanceCountersQueryData( const PerformanceQueryRangeData& );
+        void DrawPerformanceCountersStreamData( const PerformanceQueryRangeData& );
 
         // Top pipelines helpers
         void UpdateTopPipelinesExporter();

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
@@ -227,7 +227,7 @@ namespace Profiler
                 }
 
                 m_Events.push_back( TraceCounterEvent(
-                    frameGpuBeginTimestamp + Nanoseconds( data.m_PerformanceCounters.m_StreamTimestamps[i] ),
+                    GetNormalizedGpuTimestamp( data.m_PerformanceCounters.m_StreamTimestamps[i] ),
                     m_CommandQueue,
                     performanceCountersCount,
                     performanceCounterProperties.data(),


### PR DESCRIPTION
Allow limiting displayed data to a selected command buffer, just like in query-based mode.