### PR TITLE
Fix timestamp queries on NVIDIA GPUs.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
@@ -237,6 +237,22 @@ namespace Profiler
 
             // Perform deferred indirect argument buffer copies.
             FlushIndirectArgumentCopyLists();
+
+            // Flush all memory writes to make timestamp queries available for reading
+            // in the next command buffer that copies the data to the readback buffer.
+            VkMemoryBarrier memoryBarrier = {};
+            memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+            memoryBarrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+            memoryBarrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+
+            m_Profiler.m_pDevice->Callbacks.CmdPipelineBarrier(
+                m_CommandBuffer,
+                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                0,
+                1, &memoryBarrier,
+                0, nullptr,
+                0, nullptr );
         }
     }
 


### PR DESCRIPTION
Add missing pipeline barrier at the end of each profiled command buffer to make all timestamp query writes visible in the subsequent command buffers.