### PR TITLE
Fix Coverity issues.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_performance_counters_intel.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_performance_counters_intel.cpp
@@ -105,6 +105,17 @@ namespace
             return nullptr;
         }
     }
+
+    template<typename T>
+    PROFILER_FORCE_INLINE T MD_TTypedValue_Cast( const MD::TTypedValue_1_0* pValue )
+    {
+        if( pValue != nullptr )
+        {
+            return MD_TTypedValue_Cast<T>( *pValue );
+        }
+
+        return T();
+    }
 }
 
 namespace Profiler
@@ -160,14 +171,14 @@ namespace Profiler
         // Read device properties
         if( result == VK_SUCCESS )
         {
-            const MD::TTypedValue_1_0* pGpuTimestampFrequency = m_pDevice->GetGlobalSymbolValueByName( "GpuTimestampFrequency" );
-            const MD::TTypedValue_1_0* pGpuTimestampMax = m_pDevice->GetGlobalSymbolValueByName( "MaxTimestamp" );
+            const uint64_t gpuTimestampFrequency = MD_TTypedValue_Cast<uint64_t>( m_pDevice->GetGlobalSymbolValueByName( "GpuTimestampFrequency" ) );
+            const uint64_t gpuTimestampMax = MD_TTypedValue_Cast<uint64_t>( m_pDevice->GetGlobalSymbolValueByName( "MaxTimestamp" ) );
 
-            if( pGpuTimestampFrequency && pGpuTimestampMax )
+            if( gpuTimestampFrequency && gpuTimestampMax )
             {
                 m_GpuTimestampQueryPeriod = m_pVulkanDevice->pPhysicalDevice->Properties.limits.timestampPeriod;
-                m_GpuTimestampPeriod = 1e9 / MD_TTypedValue_Cast<uint64_t>( *pGpuTimestampFrequency );
-                m_GpuTimestampMax = MD_TTypedValue_Cast<uint64_t>( *pGpuTimestampMax );
+                m_GpuTimestampPeriod = 1e9 / gpuTimestampFrequency;
+                m_GpuTimestampMax = gpuTimestampMax;
                 m_GpuTimestampIs32Bit = ( m_GpuTimestampMax <= static_cast<uint64_t>( UINT32_MAX * m_GpuTimestampPeriod ) );
             }
             else
@@ -464,6 +475,7 @@ namespace Profiler
         m_pConcurrentGroupParams = nullptr;
 
         m_SamplingMode = VK_PROFILER_PERFORMANCE_COUNTERS_SAMPLING_MODE_QUERY_EXT;
+        m_SamplingPeriodInNanoseconds = 25'000;
 
         m_GpuTimestampQueryPeriod = 1.0;
         m_GpuTimestampPeriod = 1.0;

--- a/VkLayer_profiler_layer/profiler_overlay/imgui_widgets/imgui_breakdown_ex.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/imgui_widgets/imgui_breakdown_ex.cpp
@@ -48,6 +48,8 @@ namespace ImGuiX
         static std::mt19937 random;
         random.seed( 0 );
 
+        if( !label ) label = "";
+
         // Implementation is based on ImGui::PlotEx function (which is called by PlotHistogram).
 
         ImGuiContext& g = *GImGui;
@@ -56,7 +58,7 @@ namespace ImGuiX
             return;
 
         const ImGuiStyle& style = g.Style;
-        const ImGuiID id = window->GetID( label ? label : "" );
+        const ImGuiID id = window->GetID( label );
 
         PushItemWidth( -1 );
 

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -7903,10 +7903,18 @@ namespace Profiler
     void ProfilerOverlayOutput::SaveTraceToFile( const std::string& fileName, const DeviceProfilerFrameData& data )
     {
         DeviceProfilerTraceSerializer serializer( m_Frontend );
-        DeviceProfilerTraceSerializationResult result = serializer.Serialize( fileName, data );
 
-        m_SerializationSucceeded = result.m_Succeeded;
-        m_SerializationMessage = result.m_Message;
+        m_SerializationSucceeded = serializer.Serialize( fileName, data );
+
+        for( const std::string& error : serializer.GetErrorMessages() )
+        {
+            m_SerializationMessage += error + "\n";
+        }
+
+        if( m_SerializationSucceeded )
+        {
+            m_SerializationMessage += "Saved trace to\n" + fileName;
+        }
 
         // Display message box
         m_SerializationFinishTimestamp = std::chrono::high_resolution_clock::now();

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
@@ -34,6 +34,7 @@
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <iostream>
 
 #include <nlohmann/json.hpp>
 
@@ -154,10 +155,15 @@ namespace Profiler
     \*************************************************************************/
     bool DeviceProfilerTraceSerializer::OpenOutputFile( const std::string& fileName )
     {
+        // Clear exceptions mask to prevent throwing any exceptions from the stream functions.
+        m_OutputFile.exceptions( 0 );
+
+        // Open the file for writing.
         m_OutputFile.open( fileName, std::ios::out | std::ios::trunc | std::ios::binary );
 
-        if( !m_OutputFile.is_open() )
+        if( m_OutputFile.fail() )
         {
+            m_ErrorMessages.push_back( "Could not open file '" + fileName + "' for writing." );
             return false;
         }
 
@@ -181,12 +187,20 @@ namespace Profiler
         Close the output file.
 
     \*************************************************************************/
-    void DeviceProfilerTraceSerializer::CloseOutputFile()
+    bool DeviceProfilerTraceSerializer::CloseOutputFile()
     {
         if( m_OutputFile.is_open() )
         {
             m_OutputFile.close();
+
+            if( m_OutputFile.fail() )
+            {
+                m_ErrorMessages.push_back( "Error while closing the output file." );
+                return false;
+            }
         }
+
+        return true;
     }
 
     /*************************************************************************\
@@ -241,12 +255,13 @@ namespace Profiler
         Serialize collected results to the trace events file.
 
     \*************************************************************************/
-    DeviceProfilerTraceSerializationResult DeviceProfilerTraceSerializer::Serialize( const DeviceProfilerFrameData& data )
+    bool DeviceProfilerTraceSerializer::Serialize( const DeviceProfilerFrameData& data )
     {
         // Skip frames that didn't execute any profiled command buffers
         if( data.m_BeginTimestamp == 0 && data.m_EndTimestamp == 0 )
         {
-            return { false, "Frame contains no profiled command buffer executions.\n" };
+            m_ErrorMessages.push_back( "Frame contains no profiled command buffer executions." );
+            return false;
         }
 
         // Setup state for serialization
@@ -374,7 +389,13 @@ namespace Profiler
 
         m_pData = nullptr;
 
-        return { true, "Saved trace to file.\n" };
+        if( m_OutputFile.fail() )
+        {
+            m_ErrorMessages.push_back( "Error while writing events to the output file." );
+            return false;
+        }
+
+        return true;
     }
 
     /*************************************************************************\
@@ -386,19 +407,43 @@ namespace Profiler
         Write collected results to the trace file.
 
     \*************************************************************************/
-    DeviceProfilerTraceSerializationResult DeviceProfilerTraceSerializer::Serialize( const std::string& fileName, const DeviceProfilerFrameData& data )
+    bool DeviceProfilerTraceSerializer::Serialize( const std::string& fileName, const DeviceProfilerFrameData& data )
     {
-        if( !OpenOutputFile( fileName ) )
+        bool result = OpenOutputFile( fileName );
+        if( result )
         {
-            return { false, "Could not open output file.\n" };
+            result &= Serialize( data );
+            result &= CloseOutputFile();
         }
-
-        // Write data to the JSON file.
-        DeviceProfilerTraceSerializationResult result = Serialize( data );
-
-        CloseOutputFile();
-
         return result;
+    }
+
+    /*************************************************************************\
+
+    Function:
+        GetErrorMessages
+
+    Description:
+        Returns the list of error messages generated during serialization.
+
+    \*************************************************************************/
+    const std::list<std::string>& DeviceProfilerTraceSerializer::GetErrorMessages() const
+    {
+        return m_ErrorMessages;
+    }
+
+    /*************************************************************************\
+
+    Function:
+        ClearErrorMessages
+
+    Description:
+        Clears the list of error messages.
+
+    \*************************************************************************/
+    void DeviceProfilerTraceSerializer::ClearErrorMessages()
+    {
+        m_ErrorMessages.clear();
     }
 
     /*************************************************************************\
@@ -1024,6 +1069,7 @@ namespace Profiler
                     else
                     {
                         m_pTraceSerializer->Serialize( *pData );
+                        HandleErrorMessages();
                     }
 
                     m_ProcessedFrameCount++;
@@ -1132,6 +1178,7 @@ namespace Profiler
                 {
                     std::scoped_lock serializerLock( m_TraceSerializerMutex );
                     m_pTraceSerializer->Serialize( *pData );
+                    HandleErrorMessages();
                 }
 
                 lock.lock();
@@ -1158,5 +1205,27 @@ namespace Profiler
         {
             m_TraceSerializationThread.join();
         }
+    }
+
+    /*************************************************************************\
+
+    Function:
+        HandleErrorMessages
+
+    Description:
+        Read any error messages reported by the serializer and write them
+        to the standard output.
+
+        m_TraceSerializerMutex must be locked before calling this function.
+
+    \*************************************************************************/
+    void ProfilerTraceOutput::HandleErrorMessages()
+    {
+        for( const std::string& message : m_pTraceSerializer->GetErrorMessages() )
+        {
+            std::cerr << VK_LAYER_profiler_name ": " << message << std::endl;
+        }
+
+        m_pTraceSerializer->ClearErrorMessages();
     }
 }

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.cpp
@@ -156,7 +156,7 @@ namespace Profiler
     bool DeviceProfilerTraceSerializer::OpenOutputFile( const std::string& fileName )
     {
         // Clear exceptions mask to prevent throwing any exceptions from the stream functions.
-        m_OutputFile.exceptions( 0 );
+        m_OutputFile.exceptions( std::ios::iostate( 0 ) );
 
         // Open the file for writing.
         m_OutputFile.open( fileName, std::ios::out | std::ios::trunc | std::ios::binary );

--- a/VkLayer_profiler_layer/profiler_trace/profiler_trace.h
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_trace.h
@@ -24,6 +24,7 @@
 #include <nlohmann/json.hpp>
 #include <vulkan/vulkan.h>
 #include <atomic>
+#include <list>
 #include <vector>
 #include <string>
 #include <mutex>
@@ -71,10 +72,13 @@ namespace Profiler
         ~DeviceProfilerTraceSerializer();
 
         bool OpenOutputFile( const std::string& fileName );
-        void CloseOutputFile();
+        bool CloseOutputFile();
 
-        DeviceProfilerTraceSerializationResult Serialize( const struct DeviceProfilerFrameData& data );
-        DeviceProfilerTraceSerializationResult Serialize( const std::string& fileName, const struct DeviceProfilerFrameData& data );
+        bool Serialize( const struct DeviceProfilerFrameData& data );
+        bool Serialize( const std::string& fileName, const struct DeviceProfilerFrameData& data );
+
+        void ClearErrorMessages();
+        const std::list<std::string>& GetErrorMessages() const;
 
         static std::string GetDefaultTraceFileName( int samplingMode );
 
@@ -83,6 +87,8 @@ namespace Profiler
 
         class DeviceProfilerStringSerializer* m_pStringSerializer;
         class DeviceProfilerJsonSerializer* m_pJsonSerializer;
+
+        std::list<std::string> m_ErrorMessages;
 
         // Output file
         std::ofstream m_OutputFile;
@@ -178,5 +184,7 @@ namespace Profiler
 
         void TraceSerializationThreadProc();
         void StopTraceSerializationThread();
+
+        void HandleErrorMessages();
     };
 }


### PR DESCRIPTION
This PR addresses the following issues found in Coverity scan:
- Added missing member initialization.
- Fixed potential division by zero in Intel performance counters implementation.
- Disabled std::fstream exceptions in trace serializer and added a more generic error reporting mechanism.
- Fixed nullptr label handling in the custom ImGui breakdown plot widget.