### PR TITLE
Fix render pass and secondary command buffer tracking.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
@@ -782,36 +782,28 @@ namespace Profiler
         {
             const DeviceProfilerPipelineType pipelineType = drawcall.GetPipelineType();
 
-            // Insert a timestamp in per-render pass mode if command is recorded outside of the render pass
-            // and the internal render pass has changed.
-            DeviceProfilerRenderPassData* pPreviousRenderPassData = m_pCurrentRenderPassData;
-            DeviceProfilerSubpassData* pPreviousSubpassData = m_pCurrentSubpassData;
-
-            // Pointer to the previous pipeline to update the end timestamp if needed.
-            DeviceProfilerPipelineData* pPreviousPipelineData = nullptr;
-
             // Setup pipeline
             switch( pipelineType )
             {
             case DeviceProfilerPipelineType::eNone:
             case DeviceProfilerPipelineType::eDebug:
-                SetupCommandBufferForStatCounting( { VK_NULL_HANDLE }, &pPreviousPipelineData );
+                SetupCommandBufferForStatCounting( { VK_NULL_HANDLE } );
                 break;
 
             case DeviceProfilerPipelineType::eGraphics:
-                SetupCommandBufferForStatCounting( m_GraphicsPipeline, &pPreviousPipelineData );
+                SetupCommandBufferForStatCounting( m_GraphicsPipeline );
                 break;
 
             case DeviceProfilerPipelineType::eCompute:
-                SetupCommandBufferForStatCounting( m_ComputePipeline, &pPreviousPipelineData );
+                SetupCommandBufferForStatCounting( m_ComputePipeline );
                 break;
 
             case DeviceProfilerPipelineType::eRayTracingKHR:
-                SetupCommandBufferForStatCounting( m_RayTracingPipeline, &pPreviousPipelineData );
+                SetupCommandBufferForStatCounting( m_RayTracingPipeline );
                 break;
 
             default: // Internal pipelines
-                SetupCommandBufferForStatCounting( m_Profiler.GetPipeline( (VkPipeline)pipelineType ), &pPreviousPipelineData );
+                SetupCommandBufferForStatCounting( m_Profiler.GetPipeline( (VkPipeline)pipelineType ) );
                 break;
             }
 
@@ -828,81 +820,52 @@ namespace Profiler
             // Increment drawcall stats
             m_Stats.AddCount( drawcall );
 
-            if( (m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_DRAWCALL_EXT) ||
-                ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_PIPELINE_EXT) &&
-                    (m_pCurrentPipelineData != pPreviousPipelineData)) ||
-                ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
-                    (pPreviousRenderPassData != m_pCurrentRenderPassData)) )
+            uint64_t timestampIndex = UINT64_MAX;
+
+            if( m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_DRAWCALL_EXT )
             {
                 // Begin timestamp query
-                const uint64_t timestampIndex =
-                    m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
-
-                // Update draw begin timestamp index.
-                if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_DRAWCALL_EXT )
+                if( timestampIndex == UINT64_MAX )
                 {
-                    m_pCurrentDrawcallData->m_BeginTimestamp.m_Index = timestampIndex;
+                    timestampIndex = m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
+                }
+
+                m_pCurrentDrawcallData->m_BeginTimestamp.m_Index = timestampIndex;
+            }
+
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT )
+            {
+                // Begin timestamp query
+                if( timestampIndex == UINT64_MAX )
+                {
+                    timestampIndex = m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
                 }
 
                 // Update pipeline begin timestamp index.
-                if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) &&
-                    (m_pCurrentPipelineData->m_BeginTimestamp.m_Index == UINT64_MAX) )
+                if( m_pCurrentPipelineData->m_BeginTimestamp.m_Index == UINT64_MAX )
                 {
                     m_pCurrentPipelineData->m_BeginTimestamp.m_Index = timestampIndex;
-
-                    // Update end timestamp of the previous pipeline.
-                    if( pPreviousPipelineData != nullptr )
-                    {
-                        if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_DRAWCALL_EXT) &&
-                            !pPreviousPipelineData->m_Drawcalls.empty() &&
-                            (pPreviousPipelineData->m_Drawcalls.back().m_EndTimestamp.m_Index != UINT64_MAX) )
-                        {
-                            pPreviousPipelineData->m_EndTimestamp =
-                                pPreviousPipelineData->m_Drawcalls.back().m_EndTimestamp;
-                        }
-                        else
-                        {
-                            pPreviousPipelineData->m_EndTimestamp.m_Index = timestampIndex;
-                        }
-                    }
                 }
+            }
 
-                // Update subpass begin timestamp index.
-                if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
-                    (m_pCurrentSubpassData->m_BeginTimestamp.m_Index == UINT64_MAX) )
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
+            {
+                // Begin timestamp query
+                if( timestampIndex == UINT64_MAX )
                 {
-                    m_pCurrentSubpassData->m_BeginTimestamp.m_Index = timestampIndex;
-
-                    // Update end timestamp of the previous subpass.
-                    if( pPreviousSubpassData != nullptr )
-                    {
-                        if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) &&
-                            (pPreviousSubpassData->m_Contents == VK_SUBPASS_CONTENTS_INLINE ||
-                                pPreviousSubpassData->m_Contents == VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT) &&
-                            !pPreviousSubpassData->m_Data.empty() &&
-                            (pPreviousSubpassData->m_Data.back().GetType() == DeviceProfilerSubpassDataType::ePipeline) )
-                        {
-                            auto& pipeline = std::get<DeviceProfilerPipelineData>( pPreviousSubpassData->m_Data.back() );
-                            pPreviousSubpassData->m_EndTimestamp = pipeline.m_EndTimestamp;
-                        }
-                        else
-                        {
-                            pPreviousSubpassData->m_EndTimestamp.m_Index = timestampIndex;
-                        }
-                    }
+                    timestampIndex = m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
                 }
 
                 // Update render pass begin timestamp index.
-                if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
-                    (m_pCurrentRenderPassData->m_BeginTimestamp.m_Index == UINT64_MAX) )
+                if( m_pCurrentRenderPassData->m_BeginTimestamp.m_Index == UINT64_MAX )
                 {
                     m_pCurrentRenderPassData->m_BeginTimestamp.m_Index = timestampIndex;
+                }
 
-                    // Update end timestamp of the previous render pass.
-                    if( pPreviousRenderPassData != nullptr )
-                    {
-                        pPreviousRenderPassData->m_EndTimestamp = pPreviousSubpassData->m_EndTimestamp;
-                    }
+                // Update subpass begin timestamp index.
+                if( m_pCurrentSubpassData->m_BeginTimestamp.m_Index == UINT64_MAX )
+                {
+                    m_pCurrentSubpassData->m_BeginTimestamp.m_Index = timestampIndex;
                 }
             }
         }
@@ -1463,11 +1426,8 @@ namespace Profiler
 
         if( m_ProfilingEnabled )
         {
-            if( m_pCurrentRenderPassData )
-            {
-                // Insert end timestamp at the end of the previous subpass.
-                EndSubpass();
-            }
+            // Finalize render pass instrumentation.
+            EndRenderPass();
 
             if( m_Profiler.m_Config.m_CaptureIndirectArguments )
             {
@@ -1522,10 +1482,46 @@ namespace Profiler
     /***********************************************************************************\
 
     Function:
+        EndPipeline
+
+    Description:
+        Marks end of the current pipeline.
+
+    \***********************************************************************************/
+    void ProfilerCommandBuffer::EndPipeline()
+    {
+        TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
+
+        if( m_pCurrentPipelineData )
+        {
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT )
+            {
+                // Reuse drawcall end timestamp if available.
+                auto lastDrawcallIt = m_pCurrentPipelineData->m_Drawcalls.rbegin();
+                if( lastDrawcallIt != m_pCurrentPipelineData->m_Drawcalls.rend() )
+                {
+                    m_pCurrentPipelineData->m_EndTimestamp = lastDrawcallIt->m_EndTimestamp;
+                }
+
+                if( m_pCurrentPipelineData->m_EndTimestamp.m_Index == UINT64_MAX )
+                {
+                    m_pCurrentPipelineData->m_EndTimestamp.m_Index =
+                        m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
+                }
+            }
+
+            // Clear pipeline-scoped pointer.
+            m_pCurrentPipelineData = nullptr;
+        }
+    }
+
+    /***********************************************************************************\
+
+    Function:
         EndSubpass
 
     Description:
-        Marks end of current render pass subpass.
+        Marks end of the current render pass subpass.
 
     \***********************************************************************************/
     void ProfilerCommandBuffer::EndSubpass()
@@ -1534,13 +1530,12 @@ namespace Profiler
 
         if( m_pCurrentSubpassData )
         {
-            // Render pass must be valid.
-            assert( m_pCurrentRenderPassData );
+            EndPipeline();
 
             // Check if any attachments are resolved at the end of current subpass.
             // m_pCurrentRenderPass may be null in case of dynamic rendering.
-            if( (m_pCurrentRenderPass != nullptr) &&
-                (m_CurrentSubpassIndex != DeviceProfilerSubpassData::ImplicitSubpassIndex) )
+            if( ( m_pCurrentRenderPass != nullptr ) &&
+                ( m_CurrentSubpassIndex != DeviceProfilerSubpassData::ImplicitSubpassIndex ) )
             {
                 m_Stats.m_ResolveStats.m_Count +=
                     m_pCurrentRenderPass->m_Subpasses[m_CurrentSubpassIndex].m_ResolveCount;
@@ -1549,35 +1544,67 @@ namespace Profiler
             if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
             {
                 // Send timestamp query at the end of the subpass.
-                if( (m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_DRAWCALL_EXT) &&
-                    (m_pCurrentPipelineData) &&
-                    !(m_pCurrentPipelineData->m_Drawcalls.empty()) &&
-                    (m_pCurrentPipelineData->m_Drawcalls.back().m_EndTimestamp.m_Index != UINT64_MAX) )
+                auto lastSubpassContentsIt = m_pCurrentSubpassData->m_Data.rbegin();
+                if( lastSubpassContentsIt != m_pCurrentSubpassData->m_Data.rend() )
                 {
-                    m_pCurrentSubpassData->m_EndTimestamp =
-                        m_pCurrentPipelineData->m_Drawcalls.back().m_EndTimestamp;
+                    // If the last command in the subpass is a pipeline, reuse its end timestamp for the subpass end timestamp.
+                    if( lastSubpassContentsIt->GetType() == DeviceProfilerSubpassDataType::ePipeline )
+                    {
+                        m_pCurrentSubpassData->m_EndTimestamp =
+                            std::get<DeviceProfilerPipelineData>( *lastSubpassContentsIt ).m_EndTimestamp;
+                    }
                 }
-                else
+
+                if( m_pCurrentSubpassData->m_EndTimestamp.m_Index == UINT64_MAX )
                 {
                     m_pCurrentSubpassData->m_EndTimestamp.m_Index =
                         m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
                 }
+            }
 
-                // Update timestamp of the last pipeline in the subpass.
-                if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) &&
-                    (m_pCurrentPipelineData) )
+            // Clear per-subpass pointers.
+            m_pCurrentSubpassData = nullptr;
+        }
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        EndRenderPass
+
+    Description:
+        Marks end of the current render pass.
+
+    \***********************************************************************************/
+    void ProfilerCommandBuffer::EndRenderPass()
+    {
+        TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
+
+        if( m_pCurrentRenderPassData )
+        {
+            EndSubpass();
+
+            // Insert a timestamp query at the render pass boundary.
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
+            {
+                // Reuse subpass end timestamp if available.
+                auto lastSubpassIt = m_pCurrentRenderPassData->m_Subpasses.rbegin();
+                if( lastSubpassIt != m_pCurrentRenderPassData->m_Subpasses.rend() )
                 {
-                    m_pCurrentPipelineData->m_EndTimestamp = m_pCurrentSubpassData->m_EndTimestamp;
+                    m_pCurrentRenderPassData->m_EndTimestamp = lastSubpassIt->m_EndTimestamp;
                 }
 
-                // Update the end timestamp of the current render-pass.
-                m_pCurrentRenderPassData->m_EndTimestamp = m_pCurrentSubpassData->m_EndTimestamp;
+                if( m_pCurrentRenderPassData->m_EndTimestamp.m_Index == UINT64_MAX )
+                {
+                    m_pCurrentRenderPassData->m_EndTimestamp.m_Index =
+                        m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
+                }
             }
-        }
 
-        // Clear per-subpass pointers.
-        m_pCurrentSubpassData = nullptr;
-        m_pCurrentPipelineData = nullptr;
+            // Clear renderpass-scoped pointers.
+            m_pCurrentRenderPass = nullptr;
+            m_pCurrentRenderPassData = nullptr;
+        }
     }
 
     /***********************************************************************************\
@@ -1593,32 +1620,11 @@ namespace Profiler
         previously owned by the vector.
 
     \***********************************************************************************/
-    void ProfilerCommandBuffer::SetupCommandBufferForStatCounting( const DeviceProfilerPipeline& pipeline, DeviceProfilerPipelineData** ppPreviousPipelineData )
+    void ProfilerCommandBuffer::SetupCommandBufferForStatCounting( const DeviceProfilerPipeline& pipeline )
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
         const DeviceProfilerRenderPassType renderPassType = GetRenderPassTypeFromPipelineType( pipeline.m_Type );
-
-        // Save index of the current pipeline
-        size_t previousPipelineIndex = SIZE_MAX;
-        DeviceProfilerSubpassData* pPreviousSubpassData = nullptr;
-
-        if( m_pCurrentPipelineData )
-        {
-            assert( m_pCurrentSubpassData );
-            pPreviousSubpassData = m_pCurrentSubpassData;
-            previousPipelineIndex = m_pCurrentSubpassData->m_Data.size();
-
-            while( (previousPipelineIndex--) > 0 )
-            {
-                auto& data = m_pCurrentSubpassData->m_Data[previousPipelineIndex];
-                if( (data.GetType() == DeviceProfilerSubpassDataType::ePipeline) &&
-                    (&std::get<DeviceProfilerPipelineData>( data ) == m_pCurrentPipelineData) )
-                {
-                    break;
-                }
-            }
-        }
 
         // Check if we're in render pass
         if( !m_pCurrentRenderPassData ||
@@ -1626,15 +1632,11 @@ namespace Profiler
                 (m_pCurrentRenderPassData->m_Dynamic == false) &&
                 (m_pCurrentRenderPassData->m_Type != renderPassType)) )
         {
-            // Perform common operations for ending the current render pass and beginning a new one
-            PreBeginRenderPassCommonProlog();
+            EndRenderPass();
 
             m_pCurrentRenderPassData = &m_Data.m_RenderPasses.emplace_back();
             m_pCurrentRenderPassData->m_Handle = VK_NULL_HANDLE;
             m_pCurrentRenderPassData->m_Type = renderPassType;
-
-            // Submit timestamp query at the beginning of the new render pass
-            PreBeginRenderPassCommonEpilog();
         }
 
         // Check if current subpass allows inline commands
@@ -1642,7 +1644,6 @@ namespace Profiler
             ((m_pCurrentSubpassData->m_Contents != VK_SUBPASS_CONTENTS_INLINE) &&
                 (m_pCurrentSubpassData->m_Contents != VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT)) )
         {
-            // Submit timestamp query at the end of the previous subpass
             EndSubpass();
 
             m_pCurrentSubpassData = &m_pCurrentRenderPassData->m_Subpasses.emplace_back();
@@ -1658,13 +1659,9 @@ namespace Profiler
             ((m_pCurrentPipelineData->m_UsesShaderObjects || pipeline.m_UsesShaderObjects) &&
                 (m_pCurrentPipelineData->m_ShaderTuple.m_Hash != pipeline.m_ShaderTuple.m_Hash)) )
         {
-            m_pCurrentPipelineData = &std::get<DeviceProfilerPipelineData>( m_pCurrentSubpassData->m_Data.emplace_back( pipeline ) );
-        }
+            EndPipeline();
 
-        // Return previous pipeline
-        if( pPreviousSubpassData && previousPipelineIndex != SIZE_MAX )
-        {
-            (*ppPreviousPipelineData) = &std::get<DeviceProfilerPipelineData>( pPreviousSubpassData->m_Data[previousPipelineIndex] );
+            m_pCurrentPipelineData = &std::get<DeviceProfilerPipelineData>( m_pCurrentSubpassData->m_Data.emplace_back( pipeline ) );
         }
     }
 
@@ -1686,15 +1683,11 @@ namespace Profiler
                 (m_pCurrentRenderPassData->m_Dynamic == false) &&
                 (m_pCurrentRenderPassData->m_Type != DeviceProfilerRenderPassType::eNone)) )
         {
-            // Perform common operations for ending the current render pass and beginning a new one
-            PreBeginRenderPassCommonProlog();
+            EndRenderPass();
 
             m_pCurrentRenderPassData = &m_Data.m_RenderPasses.emplace_back();
             m_pCurrentRenderPassData->m_Handle = VK_NULL_HANDLE;
             m_pCurrentRenderPassData->m_Type = DeviceProfilerRenderPassType::eNone;
-
-            // Submit timestamp query at the beginning of the new render pass
-            PreBeginRenderPassCommonEpilog();
         }
 
         // Check if current subpass allows secondary command buffers
@@ -1702,7 +1695,6 @@ namespace Profiler
             ((m_pCurrentSubpassData->m_Contents != VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS) &&
                 (m_pCurrentSubpassData->m_Contents != VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT)) )
         {
-            // Submit timestamp query at the end of the previous subpass
             EndSubpass();
 
             m_pCurrentSubpassData = &m_pCurrentRenderPassData->m_Subpasses.emplace_back();

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
@@ -312,8 +312,7 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        if( (m_ProfilingEnabled) &&
-            (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT) )
+        if( m_ProfilingEnabled )
         {
             PreBeginRenderPassCommonProlog();
 
@@ -353,15 +352,18 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        if( (m_ProfilingEnabled) &&
-            (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT) )
+        if( m_ProfilingEnabled )
         {
-            if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) ||
-                ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
-                    m_Profiler.m_Config.m_EnableRenderPassBeginEndProfiling) )
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
             {
-                m_pCurrentRenderPassData->m_Begin.m_EndTimestamp.m_Index =
-                    m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
+                if( m_pCurrentRenderPassData->HasBeginCommand() &&
+                    ((m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) ||
+                      ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
+                        m_Profiler.m_Config.m_EnableRenderPassBeginEndProfiling)) )
+                {
+                    m_pCurrentRenderPassData->m_Begin.m_EndTimestamp.m_Index =
+                        m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
+                }
             }
 
             // Begin first subpass
@@ -382,19 +384,22 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        if( (m_ProfilingEnabled) &&
-            (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT) )
+        if( m_ProfilingEnabled )
         {
             // End currently profiled subpass
             EndSubpass();
 
-            // Record final transitions and resolves
-            if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) ||
-                ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
-                    m_Profiler.m_Config.m_EnableRenderPassBeginEndProfiling) )
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
             {
-                m_pCurrentRenderPassData->m_End.m_BeginTimestamp.m_Index =
-                    m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
+                // Record final transitions and resolves
+                if( m_pCurrentRenderPassData->HasEndCommand() &&
+                    ((m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) ||
+                      ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
+                        m_Profiler.m_Config.m_EnableRenderPassBeginEndProfiling)) )
+                {
+                    m_pCurrentRenderPassData->m_End.m_BeginTimestamp.m_Index =
+                        m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
+                }
             }
         }
     }
@@ -412,23 +417,32 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        if( (m_ProfilingEnabled) &&
-            (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT) )
+        if( m_ProfilingEnabled )
         {
-            if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) ||
-                ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
-                    m_Profiler.m_Config.m_EnableRenderPassBeginEndProfiling) )
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
             {
-                m_pCurrentRenderPassData->m_End.m_EndTimestamp.m_Index =
-                    m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
+                if( m_pCurrentRenderPassData->HasEndCommand() &&
+                    ((m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) ||
+                      ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
+                        m_Profiler.m_Config.m_EnableRenderPassBeginEndProfiling)) )
+                {
+                    m_pCurrentRenderPassData->m_End.m_EndTimestamp.m_Index =
+                        m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
 
-                // Use the end timestamp of the end command.
-                m_pCurrentRenderPassData->m_EndTimestamp = m_pCurrentRenderPassData->m_End.m_EndTimestamp;
+                    // Use the end timestamp of the end command.
+                    m_pCurrentRenderPassData->m_EndTimestamp = m_pCurrentRenderPassData->m_End.m_EndTimestamp;
+                }
+                else 
+                {
+                    // Use the end timestamp of the last subpass in this render pass.
+                    m_pCurrentRenderPassData->m_EndTimestamp = m_pCurrentRenderPassData->m_Subpasses.back().m_EndTimestamp;
+                }
             }
-            else
+
+            if( m_Profiler.m_Config.m_CaptureIndirectArguments )
             {
-                // Use the end timestamp of the last subpass in this render pass.
-                m_pCurrentRenderPassData->m_EndTimestamp = m_pCurrentRenderPassData->m_Subpasses.back().m_EndTimestamp;
+                // Record pending indirect argument buffer copies after the render pass.
+                FlushIndirectArgumentCopyLists();
             }
 
             // No more subpasses in this render pass.
@@ -437,13 +451,6 @@ namespace Profiler
             m_pCurrentRenderPassData = nullptr;
             m_pCurrentSubpassData = nullptr;
             m_pCurrentPipelineData = nullptr;
-        }
-
-        if( (m_ProfilingEnabled) &&
-            (m_Profiler.m_Config.m_CaptureIndirectArguments) )
-        {
-            // Record pending indirect argument buffer copies after the render pass.
-            FlushIndirectArgumentCopyLists();
         }
     }
 
@@ -460,8 +467,7 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        if( (m_ProfilingEnabled) &&
-            (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT) )
+        if( m_ProfilingEnabled )
         {
             PreBeginRenderPassCommonProlog();
 
@@ -601,8 +607,7 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        if( (m_ProfilingEnabled) &&
-            (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT) )
+        if( m_ProfilingEnabled )
         {
             // End currently profiled subpass before beginning new one.
             EndSubpass();
@@ -612,9 +617,12 @@ namespace Profiler
             m_pCurrentSubpassData->m_Index = ++m_CurrentSubpassIndex;
             m_pCurrentSubpassData->m_Contents = contents;
 
-            // Write begin timestamp of the subpass.
-            m_pCurrentSubpassData->m_BeginTimestamp.m_Index =
-                m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
+            {
+                // Write begin timestamp of the subpass.
+                m_pCurrentSubpassData->m_BeginTimestamp.m_Index =
+                    m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
+            }
         }
     }
 
@@ -920,7 +928,7 @@ namespace Profiler
             {
                 assert( m_pCurrentDrawcallData );
 
-                if (drawcall.GetPipelineType() != DeviceProfilerPipelineType::eDebug)
+                if( drawcall.GetPipelineType() != DeviceProfilerPipelineType::eDebug )
                 {
                     // Send a timestamp query at the end of the command.
                     m_pCurrentDrawcallData->m_EndTimestamp.m_Index =
@@ -1088,11 +1096,10 @@ namespace Profiler
     /***********************************************************************************\
 
     Function:
-        GetData
+        GetSecondaryCommandBuffers
 
     Description:
-        Reads all queried timestamps.
-        Returns structure containing ordered list of timestamps and statistics.
+        Returns a set of secondary command buffers executed in this command buffer.
 
     \***********************************************************************************/
     const std::unordered_set<ProfilerCommandBuffer*>& ProfilerCommandBuffer::GetSecondaryCommandBuffers() const
@@ -1274,6 +1281,48 @@ namespace Profiler
                 }
             }
 
+            // Collect the data from the secondary command buffers only if the sampling mode is per-command buffer.
+            else if( !m_pSecondaryCommandBuffers.empty() )
+            {
+                auto ResolveSecondaryCommandBufferData = [&]( DeviceProfilerSubpassData::Data& data )
+                {
+                    assert( data.GetType() == DeviceProfilerSubpassDataType::eCommandBuffer );
+                    auto& commandBufferData = std::get<DeviceProfilerCommandBufferData>( data );
+
+                    ProfilerCommandBuffer& secondaryCommandBuffer =
+                        *m_Profiler.m_pCommandBuffers.unsafe_at( commandBufferData.m_Handle );
+
+                    commandBufferData = secondaryCommandBuffer.GetData( reader );
+                };
+
+                for( auto& renderPass : m_Data.m_RenderPasses )
+                {
+                    for( auto& subpass : renderPass.m_Subpasses )
+                    {
+                        // Treat data as secondary command buffers if subpass contents are secondary command buffers only.
+                        if( subpass.m_Contents == VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS )
+                        {
+                            for( auto& data : subpass.m_Data )
+                            {
+                                ResolveSecondaryCommandBufferData( data );
+                            }
+                        }
+
+                        // With VK_EXT_nested_command_buffer, it is possible to insert both command buffers and inline commands in the same subpass.
+                        else if( subpass.m_Contents == VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT )
+                        {
+                            for( auto& data : subpass.m_Data )
+                            {
+                                if( data.GetType() == DeviceProfilerSubpassDataType::eCommandBuffer )
+                                {
+                                    ResolveSecondaryCommandBufferData( data );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             m_Data.m_EndTimestamp.m_Value = reader.ReadTimestampQueryResult( m_Data.m_EndTimestamp.m_Index );
 
             // Read vendor-specific data
@@ -1412,25 +1461,22 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        // End the current render pass, if any.
-        if( m_pCurrentRenderPassData != nullptr )
+        if( m_ProfilingEnabled )
         {
-            // Insert a timestamp query at the render pass boundary.
-            const uint64_t timestampIndex =
-                m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
-
-            // Update an ending timestamp for the previous render pass.
-            m_pCurrentRenderPassData->m_EndTimestamp.m_Index = timestampIndex;
-            m_pCurrentSubpassData->m_EndTimestamp.m_Index = timestampIndex;
-
-            // Update pipeline end timestamp index.
-            if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) &&
-                (m_pCurrentPipelineData != nullptr) )
+            if( m_pCurrentRenderPassData )
             {
-                m_pCurrentPipelineData->m_EndTimestamp.m_Index = timestampIndex;
+                // Insert end timestamp at the end of the previous subpass.
+                EndSubpass();
+            }
+
+            if( m_Profiler.m_Config.m_CaptureIndirectArguments )
+            {
+                // Record pending indirect argument buffer copies after the last render pass.
+                FlushIndirectArgumentCopyLists();
             }
 
             // Clear renderpass-scoped pointers.
+            m_CurrentSubpassIndex = DeviceProfilerSubpassData::ImplicitSubpassIndex;
             m_pCurrentRenderPass = nullptr;
             m_pCurrentRenderPassData = nullptr;
             m_pCurrentSubpassData = nullptr;
@@ -1452,17 +1498,22 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        // Ensure there are free queries that can be used in the render pass.
-        // The spec forbids resetting the pools inside the render pass scope, so they have to be allocated now.
-        m_pQueryPool->PreallocateQueries( m_CommandBuffer );
+        // Begin render pass instrumentation.
+        if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
+        {
+            // Ensure there are free queries that can be used in the render pass.
+            // The spec forbids resetting the pools inside the render pass scope, so they have to be allocated now.
+            m_pQueryPool->PreallocateQueries( m_CommandBuffer );
 
-        m_pCurrentRenderPassData->m_BeginTimestamp.m_Index =
-            m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
+            m_pCurrentRenderPassData->m_BeginTimestamp.m_Index =
+                m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
+        }
 
         // Record initial transitions and clears.
-        if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) ||
-            ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
-                m_Profiler.m_Config.m_EnableRenderPassBeginEndProfiling) )
+        if( m_pCurrentRenderPassData->HasBeginCommand() &&
+            ((m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) ||
+              ((m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_RENDER_PASS_EXT) &&
+                m_Profiler.m_Config.m_EnableRenderPassBeginEndProfiling)) )
         {
             m_pCurrentRenderPassData->m_Begin.m_BeginTimestamp = m_pCurrentRenderPassData->m_BeginTimestamp;
         }
@@ -1495,35 +1546,38 @@ namespace Profiler
                     m_pCurrentRenderPass->m_Subpasses[m_CurrentSubpassIndex].m_ResolveCount;
             }
 
-            // Send timestamp query at the end of the subpass.
-            if( (m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_DRAWCALL_EXT) &&
-                (m_pCurrentPipelineData) &&
-                !(m_pCurrentPipelineData->m_Drawcalls.empty()) &&
-                (m_pCurrentPipelineData->m_Drawcalls.back().m_EndTimestamp.m_Index != UINT64_MAX) )
+            if( m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_RENDER_PASS_EXT )
             {
-                m_pCurrentSubpassData->m_EndTimestamp =
-                    m_pCurrentPipelineData->m_Drawcalls.back().m_EndTimestamp;
-            }
-            else
-            {
-                m_pCurrentSubpassData->m_EndTimestamp.m_Index =
-                    m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
-            }
+                // Send timestamp query at the end of the subpass.
+                if( (m_Profiler.m_Config.m_SamplingMode == VK_PROFILER_MODE_PER_DRAWCALL_EXT) &&
+                    (m_pCurrentPipelineData) &&
+                    !(m_pCurrentPipelineData->m_Drawcalls.empty()) &&
+                    (m_pCurrentPipelineData->m_Drawcalls.back().m_EndTimestamp.m_Index != UINT64_MAX) )
+                {
+                    m_pCurrentSubpassData->m_EndTimestamp =
+                        m_pCurrentPipelineData->m_Drawcalls.back().m_EndTimestamp;
+                }
+                else
+                {
+                    m_pCurrentSubpassData->m_EndTimestamp.m_Index =
+                        m_pQueryPool->WriteTimestamp( m_CommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT );
+                }
 
-            // Update timestamp of the last pipeline in the subpass.
-            if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) &&
-                (m_pCurrentPipelineData) )
-            {
-                m_pCurrentPipelineData->m_EndTimestamp = m_pCurrentSubpassData->m_EndTimestamp;
+                // Update timestamp of the last pipeline in the subpass.
+                if( (m_Profiler.m_Config.m_SamplingMode <= VK_PROFILER_MODE_PER_PIPELINE_EXT) &&
+                    (m_pCurrentPipelineData) )
+                {
+                    m_pCurrentPipelineData->m_EndTimestamp = m_pCurrentSubpassData->m_EndTimestamp;
+                }
+
+                // Update the end timestamp of the current render-pass.
+                m_pCurrentRenderPassData->m_EndTimestamp = m_pCurrentSubpassData->m_EndTimestamp;
             }
-
-            // Update the end timestamp of the current render-pass.
-            m_pCurrentRenderPassData->m_EndTimestamp = m_pCurrentSubpassData->m_EndTimestamp;
-
-            // Clear per-subpass pointers.
-            m_pCurrentSubpassData = nullptr;
-            m_pCurrentPipelineData = nullptr;
         }
+
+        // Clear per-subpass pointers.
+        m_pCurrentSubpassData = nullptr;
+        m_pCurrentPipelineData = nullptr;
     }
 
     /***********************************************************************************\
@@ -1572,11 +1626,15 @@ namespace Profiler
                 (m_pCurrentRenderPassData->m_Dynamic == false) &&
                 (m_pCurrentRenderPassData->m_Type != renderPassType)) )
         {
-            EndSubpass();
+            // Perform common operations for ending the current render pass and beginning a new one
+            PreBeginRenderPassCommonProlog();
 
             m_pCurrentRenderPassData = &m_Data.m_RenderPasses.emplace_back();
             m_pCurrentRenderPassData->m_Handle = VK_NULL_HANDLE;
             m_pCurrentRenderPassData->m_Type = renderPassType;
+
+            // Submit timestamp query at the beginning of the new render pass
+            PreBeginRenderPassCommonEpilog();
         }
 
         // Check if current subpass allows inline commands
@@ -1584,6 +1642,7 @@ namespace Profiler
             ((m_pCurrentSubpassData->m_Contents != VK_SUBPASS_CONTENTS_INLINE) &&
                 (m_pCurrentSubpassData->m_Contents != VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT)) )
         {
+            // Submit timestamp query at the end of the previous subpass
             EndSubpass();
 
             m_pCurrentSubpassData = &m_pCurrentRenderPassData->m_Subpasses.emplace_back();
@@ -1627,11 +1686,15 @@ namespace Profiler
                 (m_pCurrentRenderPassData->m_Dynamic == false) &&
                 (m_pCurrentRenderPassData->m_Type != DeviceProfilerRenderPassType::eNone)) )
         {
-            EndSubpass();
+            // Perform common operations for ending the current render pass and beginning a new one
+            PreBeginRenderPassCommonProlog();
 
             m_pCurrentRenderPassData = &m_Data.m_RenderPasses.emplace_back();
             m_pCurrentRenderPassData->m_Handle = VK_NULL_HANDLE;
             m_pCurrentRenderPassData->m_Type = DeviceProfilerRenderPassType::eNone;
+
+            // Submit timestamp query at the beginning of the new render pass
+            PreBeginRenderPassCommonEpilog();
         }
 
         // Check if current subpass allows secondary command buffers
@@ -1639,6 +1702,7 @@ namespace Profiler
             ((m_pCurrentSubpassData->m_Contents != VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS) &&
                 (m_pCurrentSubpassData->m_Contents != VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT)) )
         {
+            // Submit timestamp query at the end of the previous subpass
             EndSubpass();
 
             m_pCurrentSubpassData = &m_pCurrentRenderPassData->m_Subpasses.emplace_back();

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
@@ -141,9 +141,11 @@ namespace Profiler
         void PreBeginRenderPassCommonProlog();
         void PreBeginRenderPassCommonEpilog();
 
+        void EndPipeline();
         void EndSubpass();
+        void EndRenderPass();
 
-        void SetupCommandBufferForStatCounting( const DeviceProfilerPipeline&, DeviceProfilerPipelineData** );
+        void SetupCommandBufferForStatCounting( const DeviceProfilerPipeline& );
         void SetupCommandBufferForSecondaryBuffers();
 
         DeviceProfilerRenderPassType GetRenderPassTypeFromPipelineType( DeviceProfilerPipelineType ) const;


### PR DESCRIPTION
Properly count implicit clears and resolves at render pass boundaries in per command buffer sampling mode.
Return secondary command buffer contents in the primary one.