### PR TITLE
Add VK_KHR_opacity_micromap extension support.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler_data.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data.cpp
@@ -386,6 +386,22 @@ static VkAccelerationStructureBuildGeometryInfoKHR* CopyAccelerationStructureBui
     for( uint32_t i = 0; i < infoCount; ++i )
     {
         totalSize += pInfos[i].geometryCount * sizeof( VkAccelerationStructureGeometryKHR );
+
+        for( uint32_t j = 0; j < pInfos[i].geometryCount; ++j )
+        {
+            const VkAccelerationStructureGeometryKHR& geometry =
+                ( pInfos[i].pGeometries != nullptr ) ? pInfos[i].pGeometries[j] : *pInfos[i].ppGeometries[j];
+
+            for( auto& structure : Profiler::PNextIterator( geometry.pNext ) )
+            {
+                switch( structure.sType )
+                {
+                case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR:
+                    totalSize += sizeof( VkAccelerationStructureGeometryMicromapDataKHR );
+                    break;
+                }
+            }
+        }
     }
 
     void* pAllocation = malloc( totalSize );
@@ -421,6 +437,37 @@ static VkAccelerationStructureBuildGeometryInfoKHR* CopyAccelerationStructureBui
             {
                 pDuplicatedGeometries[j] = *pInfos[i].ppGeometries[j];
             }
+        }
+
+        // Copy pNext chains of the geometries.
+        for( uint32_t j = 0; j < geometryCount; ++j )
+        {
+            VkAccelerationStructureGeometryKHR& geometry = pDuplicatedGeometries[j];
+
+            // Immediately after the copy pNext of each geometry is still valid.
+            const void** ppNext = &geometry.pNext;
+
+            for( auto& structure : Profiler::PNextIterator( geometry.pNext ) )
+            {
+                switch( structure.sType )
+                {
+                case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR:
+                {
+                    auto* pMicromapData = reinterpret_cast<VkAccelerationStructureGeometryMicromapDataKHR*>( pAllocation );
+                    memcpy( pMicromapData, &structure, sizeof( VkAccelerationStructureGeometryMicromapDataKHR ) );
+                    *ppNext = pMicromapData;
+                    ppNext = &pMicromapData->pNext;
+                    pAllocation = pMicromapData + 1;
+                    break;
+                }
+                default:
+                    *ppNext = nullptr;
+                    break;
+                }
+            }
+
+            // Terminate the pNext chain of the geometry.
+            *ppNext = nullptr;
         }
     }
 

--- a/VkLayer_profiler_layer/profiler/profiler_data.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data.cpp
@@ -397,8 +397,12 @@ static VkAccelerationStructureBuildGeometryInfoKHR* CopyAccelerationStructureBui
                 switch( structure.sType )
                 {
                 case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR:
+                {
+                    auto* pMicromapData = reinterpret_cast<const VkAccelerationStructureGeometryMicromapDataKHR*>( &structure );
                     totalSize += sizeof( VkAccelerationStructureGeometryMicromapDataKHR );
+                    totalSize += pMicromapData->usageCountsCount * sizeof( VkMicromapUsageKHR );
                     break;
+                }
                 }
             }
         }
@@ -455,9 +459,27 @@ static VkAccelerationStructureBuildGeometryInfoKHR* CopyAccelerationStructureBui
                 {
                     auto* pMicromapData = reinterpret_cast<VkAccelerationStructureGeometryMicromapDataKHR*>( pAllocation );
                     memcpy( pMicromapData, &structure, sizeof( VkAccelerationStructureGeometryMicromapDataKHR ) );
+
+                    auto* pUsageCounts = reinterpret_cast<VkMicromapUsageKHR*>( pMicromapData + 1 );
+                    if( pMicromapData->pUsageCounts != nullptr )
+                    {
+                        memcpy( pUsageCounts, pMicromapData->pUsageCounts, pMicromapData->usageCountsCount * sizeof( VkMicromapUsageKHR ) );
+                    }
+                    else if( pMicromapData->ppUsageCounts != nullptr )
+                    {
+                        for( uint32_t k = 0; k < pMicromapData->usageCountsCount; ++k )
+                        {
+                            pUsageCounts[k] = *pMicromapData->ppUsageCounts[k];
+                        }
+                    }
+
+                    pMicromapData->pUsageCounts = pUsageCounts;
+                    pMicromapData->ppUsageCounts = nullptr;
+
                     *ppNext = pMicromapData;
                     ppNext = &pMicromapData->pNext;
-                    pAllocation = pMicromapData + 1;
+
+                    pAllocation = pUsageCounts + pMicromapData->usageCountsCount;
                     break;
                 }
                 default:

--- a/VkLayer_profiler_layer/profiler/profiler_data.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data.cpp
@@ -149,22 +149,6 @@ void* AllocateMemoryForStructures( const T* pStructure, size_t count = 1 )
 }
 
 template<>
-size_t GetPNextChainSize( const VkAccelerationStructureBuildGeometryInfoKHR* pStructure )
-{
-    size_t size = 0;
-    for( const auto& structure : Profiler::PNextIterator( pStructure->pNext ) )
-    {
-        switch( structure.sType )
-        {
-        case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR:
-            size += GetStructureSize( reinterpret_cast<const VkAccelerationStructureGeometryMicromapDataKHR*>( &structure ) );
-            break;
-        }
-    }
-    return size;
-}
-
-template<>
 size_t GetStructureSize( const VkPipelineVertexInputStateCreateInfo* pStructure )
 {
     if( pStructure != nullptr )
@@ -272,6 +256,34 @@ size_t GetStructureSize( const VkRayTracingPipelineCreateInfoKHR* pStructure )
 }
 
 template<>
+size_t GetStructureSize( const VkAccelerationStructureGeometryMicromapDataKHR* pStructure )
+{
+    if( pStructure != nullptr )
+    {
+        return sizeof( VkAccelerationStructureGeometryMicromapDataKHR ) +
+               GetStructureArraySize( pStructure->pUsageCounts, pStructure->usageCountsCount ) +
+               GetStructureArraySize( pStructure->ppUsageCounts, pStructure->usageCountsCount );
+    }
+    return 0;
+}
+
+template<>
+size_t GetPNextChainSize( const VkAccelerationStructureGeometryKHR* pStructure )
+{
+    size_t size = 0;
+    for( const auto& structure : Profiler::PNextIterator( pStructure->pNext ) )
+    {
+        switch( structure.sType )
+        {
+        case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR:
+            size += GetStructureSize( reinterpret_cast<const VkAccelerationStructureGeometryMicromapDataKHR*>( &structure ) );
+            break;
+        }
+    }
+    return size;
+}
+
+template<>
 size_t GetStructureSize( const VkAccelerationStructureGeometryKHR* pStructure )
 {
     if( pStructure != nullptr )
@@ -319,7 +331,7 @@ size_t GetStructureSize( const VkMicromapBuildInfoEXT* pStructure )
 }
 
 template<>
-void* CopyPNextChain( const VkAccelerationStructureBuildGeometryInfoKHR* pStructure, std::byte** ppNext )
+void* CopyPNextChain( const VkAccelerationStructureGeometryKHR* pStructure, std::byte** ppNext )
 {
     VkBaseOutStructure copied = {};
     VkBaseOutStructure* pLast = &copied;
@@ -345,7 +357,7 @@ void CopyStructureTo( VkPipelineVertexInputStateCreateInfo* pDst, const VkPipeli
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkPipelineVertexInputStateCreateInfo ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->pVertexBindingDescriptions = CopyStructureArray( pSrc->pVertexBindingDescriptions, pSrc->vertexBindingDescriptionCount, ppNext );
         pDst->pVertexAttributeDescriptions = CopyStructureArray( pSrc->pVertexAttributeDescriptions, pSrc->vertexAttributeDescriptionCount, ppNext );
     }
@@ -357,7 +369,7 @@ void CopyStructureTo( VkPipelineViewportStateCreateInfo* pDst, const VkPipelineV
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkPipelineViewportStateCreateInfo ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->pViewports = CopyStructureArray( pSrc->pViewports, pSrc->viewportCount, ppNext );
         pDst->pScissors = CopyStructureArray( pSrc->pScissors, pSrc->scissorCount, ppNext );
     }
@@ -369,7 +381,7 @@ void CopyStructureTo( VkPipelineMultisampleStateCreateInfo* pDst, const VkPipeli
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkPipelineMultisampleStateCreateInfo ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->pSampleMask = CopyStructure( pSrc->pSampleMask, ppNext );
     }
 }
@@ -380,7 +392,7 @@ void CopyStructureTo( VkPipelineColorBlendStateCreateInfo* pDst, const VkPipelin
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkPipelineColorBlendStateCreateInfo ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->pAttachments = CopyStructureArray( pSrc->pAttachments, pSrc->attachmentCount, ppNext );
     }
 }
@@ -391,7 +403,7 @@ void CopyStructureTo( VkPipelineDynamicStateCreateInfo* pDst, const VkPipelineDy
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkPipelineDynamicStateCreateInfo ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->pDynamicStates = CopyStructureArray( pSrc->pDynamicStates, pSrc->dynamicStateCount, ppNext );
     }
 }
@@ -402,7 +414,7 @@ void CopyStructureTo( VkRayTracingPipelineInterfaceCreateInfoKHR* pDst, const Vk
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkRayTracingPipelineInterfaceCreateInfoKHR ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
     }
 }
 
@@ -412,7 +424,7 @@ void CopyStructureTo( VkGraphicsPipelineCreateInfo* pDst, const VkGraphicsPipeli
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkGraphicsPipelineCreateInfo ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->stageCount = 0;
         pDst->pStages = nullptr;
         pDst->pVertexInputState = CopyStructure( pSrc->pVertexInputState, ppNext );
@@ -433,7 +445,7 @@ void CopyStructureTo( VkRayTracingPipelineCreateInfoKHR* pDst, const VkRayTracin
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkRayTracingPipelineCreateInfoKHR ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->stageCount = 0;
         pDst->pStages = nullptr;
         pDst->pGroups = CopyStructureArray( pSrc->pGroups, pSrc->groupCount, ppNext );
@@ -449,9 +461,31 @@ void CopyStructureTo( VkAccelerationStructureBuildGeometryInfoKHR* pDst, const V
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkAccelerationStructureBuildGeometryInfoKHR ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->pGeometries = CopyStructureArray( pSrc->pGeometries, pSrc->geometryCount, ppNext );
         pDst->ppGeometries = CopyStructureArray( pSrc->ppGeometries, pSrc->geometryCount, ppNext );
+    }
+}
+
+template<>
+void CopyStructureTo( VkAccelerationStructureGeometryMicromapDataKHR* pDst, const VkAccelerationStructureGeometryMicromapDataKHR* pSrc, std::byte** ppNext )
+{
+    if( pSrc != nullptr )
+    {
+        memcpy( pDst, pSrc, sizeof( VkAccelerationStructureGeometryMicromapDataKHR ) );
+        pDst->pNext = nullptr; // Part of VkAccelerationStructureGeometryKHR pNext chain
+        pDst->pUsageCounts = CopyStructureArray( pSrc->pUsageCounts, pSrc->usageCountsCount, ppNext );
+        pDst->ppUsageCounts = CopyStructureArray( pSrc->ppUsageCounts, pSrc->usageCountsCount, ppNext );
+    }
+}
+
+template<>
+void CopyStructureTo( VkAccelerationStructureGeometryKHR* pDst, const VkAccelerationStructureGeometryKHR* pSrc, std::byte** ppNext )
+{
+    if( pSrc != nullptr )
+    {
+        memcpy( pDst, pSrc, sizeof( VkAccelerationStructureGeometryKHR ) );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
     }
 }
 
@@ -461,7 +495,7 @@ void CopyStructureTo( VkMicromapBuildInfoEXT* pDst, const VkMicromapBuildInfoEXT
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( VkMicromapBuildInfoEXT ) );
-        pDst->pNext = CopyPNextChain( pSrc->pNext, ppNext );
+        pDst->pNext = CopyPNextChain( pSrc, ppNext );
         pDst->pUsageCounts = CopyStructureArray( pSrc->pUsageCounts, pSrc->usageCountsCount, ppNext );
         pDst->ppUsageCounts = CopyStructureArray( pSrc->ppUsageCounts, pSrc->usageCountsCount, ppNext );
     }

--- a/VkLayer_profiler_layer/profiler/profiler_data.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data.cpp
@@ -20,6 +20,16 @@
 
 #include "profiler_data.h"
 
+template<typename T, typename = void>
+struct HasPNext : std::false_type
+{
+};
+
+template<typename T>
+struct HasPNext<T, std::void_t<decltype( &T::pNext )>> : std::true_type
+{
+};
+
 template<typename T>
 constexpr size_t GetPNextChainSize( const T* pStructure )
 {
@@ -80,6 +90,11 @@ void CopyStructureTo( T* pDst, const T* pSrc, std::byte** ppNext )
     if( pSrc != nullptr )
     {
         memcpy( pDst, pSrc, sizeof( T ) );
+
+        if constexpr( HasPNext<T>::value )
+        {
+            pDst->pNext = nullptr;
+        }
     }
 }
 

--- a/VkLayer_profiler_layer/profiler/profiler_helpers.h
+++ b/VkLayer_profiler_layer/profiler/profiler_helpers.h
@@ -35,6 +35,8 @@
 
 #include "VkLayer_profiler_layer.generated.h"
 
+#include <immintrin.h>
+
 // Exit current function without fixing the state
 #define RETURNONFAIL( VKRESULT )            \
     {                                       \
@@ -276,6 +278,62 @@ namespace Profiler
     PROFILER_FORCE_INLINE void Fill( Iterable& iterable, const ValueType& value )
     {
         std::fill( std::begin( iterable ), std::end( iterable ), value );
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        BitScanMSB
+
+    Description:
+        Find index of the most significant set bit in the given value.
+
+    \***********************************************************************************/
+    template<typename T>
+    PROFILER_FORCE_INLINE uint8_t BitScanMSB( T value )
+    {
+        unsigned long index = UINT8_MAX;
+
+#ifdef _MSC_VER
+        // Use compiler intrinsic for MSVC.
+        if constexpr( sizeof( T ) == sizeof( uint64_t ) )
+        {
+            if( _BitScanReverse64( &index, static_cast<uint64_t>( value ) ) )
+            {
+                return static_cast<uint8_t>( index );
+            }
+        }
+        else
+        {
+            if( _BitScanReverse( &index, static_cast<uint32_t>( value ) ) )
+            {
+                return static_cast<uint8_t>( index );
+            }
+        }
+#elif defined( __GNUC__ ) || defined( __clang__ )
+        // Use compiler built-in function for GCC/Clang.
+        if constexpr( sizeof( T ) == sizeof( uint64_t ) )
+        {
+            index = 63 - __builtin_clzll( static_cast<uint64_t>( value ) );
+        }
+        else
+        {
+            index = 31 - __builtin_clz( static_cast<uint32_t>( value ) );
+        }
+#else
+        // Calculate the index of the most significant set bit manually.
+        for( index = sizeof( T ) * 8; index > 0; index-- )
+        {
+            if( value & ( static_cast<T>( 1 ) << ( index - 1 ) ) )
+            {
+                return static_cast<uint8_t>( index - 1 );
+            }
+        }
+
+        index = UINT8_MAX;
+#endif
+
+        return static_cast<uint8_t>( index );
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler_helpers.h
+++ b/VkLayer_profiler_layer/profiler/profiler_helpers.h
@@ -35,8 +35,6 @@
 
 #include "VkLayer_profiler_layer.generated.h"
 
-#include <immintrin.h>
-
 // Exit current function without fixing the state
 #define RETURNONFAIL( VKRESULT )            \
     {                                       \
@@ -278,62 +276,6 @@ namespace Profiler
     PROFILER_FORCE_INLINE void Fill( Iterable& iterable, const ValueType& value )
     {
         std::fill( std::begin( iterable ), std::end( iterable ), value );
-    }
-
-    /***********************************************************************************\
-
-    Function:
-        BitScanMSB
-
-    Description:
-        Find index of the most significant set bit in the given value.
-
-    \***********************************************************************************/
-    template<typename T>
-    PROFILER_FORCE_INLINE uint8_t BitScanMSB( T value )
-    {
-        unsigned long index = UINT8_MAX;
-
-#ifdef _MSC_VER
-        // Use compiler intrinsic for MSVC.
-        if constexpr( sizeof( T ) == sizeof( uint64_t ) )
-        {
-            if( _BitScanReverse64( &index, static_cast<uint64_t>( value ) ) )
-            {
-                return static_cast<uint8_t>( index );
-            }
-        }
-        else
-        {
-            if( _BitScanReverse( &index, static_cast<uint32_t>( value ) ) )
-            {
-                return static_cast<uint8_t>( index );
-            }
-        }
-#elif defined( __GNUC__ ) || defined( __clang__ )
-        // Use compiler built-in function for GCC/Clang.
-        if constexpr( sizeof( T ) == sizeof( uint64_t ) )
-        {
-            index = 63 - __builtin_clzll( static_cast<uint64_t>( value ) );
-        }
-        else
-        {
-            index = 31 - __builtin_clz( static_cast<uint32_t>( value ) );
-        }
-#else
-        // Calculate the index of the most significant set bit manually.
-        for( index = sizeof( T ) * 8; index > 0; index-- )
-        {
-            if( value & ( static_cast<T>( 1 ) << ( index - 1 ) ) )
-            {
-                return static_cast<uint8_t>( index - 1 );
-            }
-        }
-
-        index = UINT8_MAX;
-#endif
-
-        return static_cast<uint8_t>( index );
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler_ext/CMakeLists.txt
+++ b/VkLayer_profiler_layer/profiler_ext/CMakeLists.txt
@@ -27,7 +27,8 @@ add_library (profiler_ext
     VkProfilerEXT.h
     VkProfilerEXT.cpp
     VkProfilerObjectEXT.h
-    VkProfilerObjectEXT.cpp)
+    VkProfilerObjectEXT.cpp
+    VkProfilerCustomFlagsEXT.h)
 
 target_link_libraries (profiler_ext
     PRIVATE profiler)

--- a/VkLayer_profiler_layer/profiler_ext/VkProfilerCustomFlagsEXT.h
+++ b/VkLayer_profiler_layer/profiler_ext/VkProfilerCustomFlagsEXT.h
@@ -35,7 +35,7 @@ typedef enum VkProfilerAccelerationStructureTypeFlagBitsEXT
 } VkProfilerAccelerationStructureTypeFlagBitsEXT;
 typedef VkFlags VkProfilerAccelerationStructureTypeFlagsEXT;
 
-inline VkAccelerationStructureTypeKHR vkProfilerGetAccelerationStructureTypeFromFlagsEXT(
+static inline VkAccelerationStructureTypeKHR vkProfilerGetAccelerationStructureTypeFromFlagsEXT(
     VkProfilerAccelerationStructureTypeFlagsEXT flags )
 {
     switch( flags )
@@ -57,7 +57,7 @@ inline VkAccelerationStructureTypeKHR vkProfilerGetAccelerationStructureTypeFrom
     }
 }
 
-inline VkProfilerAccelerationStructureTypeFlagsEXT vkProfilerGetAccelerationStructureFlagsFromTypeEXT(
+static inline VkProfilerAccelerationStructureTypeFlagsEXT vkProfilerGetAccelerationStructureFlagsFromTypeEXT(
     VkAccelerationStructureTypeKHR type )
 {
     switch( type )

--- a/VkLayer_profiler_layer/profiler_ext/VkProfilerCustomFlagsEXT.h
+++ b/VkLayer_profiler_layer/profiler_ext/VkProfilerCustomFlagsEXT.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Lukasz Stalmirski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <vulkan/vulkan.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum VkProfilerAccelerationStructureTypeFlagBitsEXT
+{
+    VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_BIT_EXT = 0x00000001,
+    VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_BIT_EXT = 0x00000002,
+    VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_GENERIC_BIT_EXT = 0x00000004,
+    VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_BIT_EXT = 0x00000008,
+    VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_MAX_ENUM_BIT_EXT = 0x7FFFFFFF
+} VkProfilerAccelerationStructureTypeFlagBitsEXT;
+typedef VkFlags VkProfilerAccelerationStructureTypeFlagsEXT;
+
+inline VkAccelerationStructureTypeKHR vkProfilerGetAccelerationStructureTypeFromFlagsEXT(
+    VkProfilerAccelerationStructureTypeFlagsEXT flags )
+{
+    switch( flags )
+    {
+    case VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_BIT_EXT:
+        return VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
+
+    case VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_BIT_EXT:
+        return VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+
+    case VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_GENERIC_BIT_EXT:
+        return VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
+
+    case VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_BIT_EXT:
+        return VK_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_KHR;
+
+    default:
+        return VK_ACCELERATION_STRUCTURE_TYPE_MAX_ENUM_KHR;
+    }
+}
+
+inline VkProfilerAccelerationStructureTypeFlagsEXT vkProfilerGetAccelerationStructureFlagsFromTypeEXT(
+    VkAccelerationStructureTypeKHR type )
+{
+    switch( type )
+    {
+    case VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR:
+        return VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_BIT_EXT;
+
+    case VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR:
+        return VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_BIT_EXT;
+
+    case VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR:
+        return VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_GENERIC_BIT_EXT;
+
+    case VK_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_KHR:
+        return VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_BIT_EXT;
+
+    default:
+        return 0;
+    }
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/VkLayer_profiler_layer/profiler_helpers/profiler_string_serializer.cpp
+++ b/VkLayer_profiler_layer/profiler_helpers/profiler_string_serializer.cpp
@@ -2776,10 +2776,6 @@ namespace Profiler
             return "AABBs";
         case VK_GEOMETRY_TYPE_INSTANCES_KHR:
             return "Instances";
-        case VK_GEOMETRY_TYPE_SPHERES_NV:
-            return "Spheres";
-        case VK_GEOMETRY_TYPE_LINEAR_SWEPT_SPHERES_NV:
-            return "Linear swept spheres";
         case VK_GEOMETRY_TYPE_MICROMAP_KHR:
             return "Micromap";
         }

--- a/VkLayer_profiler_layer/profiler_helpers/profiler_string_serializer.cpp
+++ b/VkLayer_profiler_layer/profiler_helpers/profiler_string_serializer.cpp
@@ -2543,6 +2543,8 @@ namespace Profiler
             return "Bottom-level";
         case VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR:
             return "Generic";
+        case VK_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_KHR:
+            return "Opacity Micromap";
         }
         return fmt::format( "Unknown type ({})", static_cast<uint32_t>( type ) );
     }
@@ -2556,20 +2558,22 @@ namespace Profiler
 
     \***********************************************************************************/
     std::string DeviceProfilerStringSerializer::GetAccelerationStructureTypeFlagNames(
-        VkFlags typeFlags,
+        VkProfilerAccelerationStructureTypeFlagsEXT typeFlags,
         const char* separator ) const
     {
         FlagsStringBuilder builder;
         builder.m_pSeparator = separator;
 
-        if( typeFlags & ( 1U << VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR ) )
+        if( typeFlags & VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_BIT_EXT )
             builder.AddFlag( "Top-level" );
-        if( typeFlags & ( 1U << VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR ) )
+        if( typeFlags & VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_BIT_EXT )
             builder.AddFlag( "Bottom-level" );
-        if( typeFlags & ( 1U << VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR ) )
+        if( typeFlags & VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_GENERIC_BIT_EXT )
             builder.AddFlag( "Generic" );
+        if( typeFlags & VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_BIT_EXT )
+            builder.AddFlag( "Opacity Micromap" );
 
-        builder.AddUnknownFlags( typeFlags, 3 );
+        builder.AddUnknownFlags( typeFlags, 4 );
 
         return builder.BuildString();
     }
@@ -2588,19 +2592,31 @@ namespace Profiler
         FlagsStringBuilder builder;
 
         if( flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR )
-            builder.AddFlag( "Allow update (1)" );
+            builder.AddFlag( "Allow update" );
         if( flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR )
-            builder.AddFlag( "Allow compaction (2)" );
+            builder.AddFlag( "Allow compaction" );
         if( flags & VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR )
-            builder.AddFlag( "Prefer fast trace (4)" );
+            builder.AddFlag( "Prefer fast trace" );
         if( flags & VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_BUILD_BIT_KHR )
-            builder.AddFlag( "Prefer fast build (8)" );
+            builder.AddFlag( "Prefer fast build" );
         if( flags & VK_BUILD_ACCELERATION_STRUCTURE_LOW_MEMORY_BIT_KHR )
-            builder.AddFlag( "Low memory (16)" );
+            builder.AddFlag( "Low memory" );
         if( flags & VK_BUILD_ACCELERATION_STRUCTURE_MOTION_BIT_NV )
-            builder.AddFlag( "Motion (32)" );
+            builder.AddFlag( "Motion" );
+        if( flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_OPACITY_MICROMAP_UPDATE_BIT_KHR )
+            builder.AddFlag( "Allow opacity micromap update" );
+        if( flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_DISABLE_OPACITY_MICROMAPS_BIT_KHR )
+            builder.AddFlag( "Allow disable opacity micromaps" );
+        if( flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_OPACITY_MICROMAP_DATA_UPDATE_BIT_EXT )
+            builder.AddFlag( "Allow opacity micromap data update" );
+        if( flags & VK_BUILD_ACCELERATION_STRUCTURE_MICROMAP_LOSSY_BIT_KHR )
+            builder.AddFlag( "Micromap lossy" );
+        if( flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_DATA_ACCESS_BIT_KHR )
+            builder.AddFlag( "Allow data access" );
+        if( flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_CLUSTER_OPACITY_MICROMAPS_BIT_NV )
+            builder.AddFlag( "Allow cluster opacity micromaps" );
 
-        builder.AddUnknownFlags( flags, 6 );
+        builder.AddUnknownFlags( flags, 12 );
 
         return builder.BuildString();
     }
@@ -2760,6 +2776,12 @@ namespace Profiler
             return "AABBs";
         case VK_GEOMETRY_TYPE_INSTANCES_KHR:
             return "Instances";
+        case VK_GEOMETRY_TYPE_SPHERES_NV:
+            return "Spheres";
+        case VK_GEOMETRY_TYPE_LINEAR_SWEPT_SPHERES_NV:
+            return "Linear swept spheres";
+        case VK_GEOMETRY_TYPE_MICROMAP_KHR:
+            return "Micromap";
         }
         return fmt::format( "Unknown type ({})", static_cast<uint32_t>( type ) );
     }

--- a/VkLayer_profiler_layer/profiler_helpers/profiler_string_serializer.h
+++ b/VkLayer_profiler_layer/profiler_helpers/profiler_string_serializer.h
@@ -22,6 +22,8 @@
 #include <vulkan/vulkan.h>
 #include <string>
 
+#include "profiler_ext/VkProfilerCustomFlagsEXT.h"
+
 namespace Profiler
 {
     class DeviceProfilerFrontend;
@@ -99,7 +101,7 @@ namespace Profiler
 
         std::string GetCopyAccelerationStructureModeName( VkCopyAccelerationStructureModeKHR mode ) const;
         std::string GetAccelerationStructureTypeName( VkAccelerationStructureTypeKHR type ) const;
-        std::string GetAccelerationStructureTypeFlagNames( VkFlags flags, const char* separator = DefaultFlagsSeparator ) const;
+        std::string GetAccelerationStructureTypeFlagNames( VkProfilerAccelerationStructureTypeFlagsEXT flags, const char* separator = DefaultFlagsSeparator ) const;
         std::string GetBuildAccelerationStructureFlagNames( VkBuildAccelerationStructureFlagsKHR flags ) const;
         std::string GetBuildAccelerationStructureModeName( VkBuildAccelerationStructureModeKHR mode ) const;
 

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -121,13 +121,11 @@ namespace Profiler
         VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR |
         VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR;
 
-    static constexpr VkFlags g_KnownAccelerationStructureTypes =
-        1 << VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR |
-        1 << VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR |
-        1 << VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
-
-    static constexpr VkFlags g_KnownMicromapTypes =
-        1 << VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+    static constexpr VkProfilerAccelerationStructureTypeFlagsEXT g_KnownAccelerationStructureTypes =
+        VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_BIT_EXT |
+        VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_BIT_EXT |
+        VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_GENERIC_BIT_EXT |
+        VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_BIT_EXT;
 
     static constexpr ImU32 g_MemoryTypesBreakdownColorMap[] = {
         IM_COL32( 110, 177, 165, 255 ),
@@ -173,8 +171,7 @@ namespace Profiler
         std::string m_NameFilter;
         VkBufferUsageFlags m_BufferUsageFilter;
         VkImageUsageFlags m_ImageUsageFilter;
-        VkFlags m_AccelerationStructureTypeFilter;
-        VkFlags m_MicromapTypeFilter;
+        VkProfilerAccelerationStructureTypeFlagsEXT m_AccelerationStructureTypeFilter;
     };
 
     struct ProfilerOverlayOutput::PerformanceQueryExporter
@@ -675,7 +672,6 @@ namespace Profiler
         m_ResourceBrowserBufferUsageFilter = g_KnownBufferUsageFlags;
         m_ResourceBrowserImageUsageFilter = g_KnownImageUsageFlags;
         m_ResourceBrowserAccelerationStructureTypeFilter = g_KnownAccelerationStructureTypes;
-        m_ResourceBrowserMicromapTypeFilter = g_KnownMicromapTypes;
         m_ResourceBrowserShowDifferences = false;
         m_ResourceInspectorImageMapSubresource = {};
         m_ResourceInspectorImageMapBlockSize = 16.f;
@@ -3997,7 +3993,6 @@ namespace Profiler
             m_pResourceListExporter->m_BufferUsageFilter = m_ResourceBrowserBufferUsageFilter;
             m_pResourceListExporter->m_ImageUsageFilter = m_ResourceBrowserImageUsageFilter;
             m_pResourceListExporter->m_AccelerationStructureTypeFilter = m_ResourceBrowserAccelerationStructureTypeFilter;
-            m_pResourceListExporter->m_MicromapTypeFilter = m_ResourceBrowserMicromapTypeFilter;
         }
         ImGui::EndDisabled();
 
@@ -4065,13 +4060,6 @@ namespace Profiler
             m_ResourceBrowserAccelerationStructureTypeFilter,
             g_KnownAccelerationStructureTypes,
             &DeviceProfilerStringSerializer::GetAccelerationStructureTypeFlagNames );
-
-        ImGui::SameLine( 0, 10.f * interfaceScale );
-        ResourceUsageFlagsFilterComboBox(
-            "Micromaps###MicromapFilter",
-            m_ResourceBrowserMicromapTypeFilter,
-            g_KnownMicromapTypes,
-            &DeviceProfilerStringSerializer::GetMicromapTypeFlagNames );
 
         ImGui::Separator();
 
@@ -4225,8 +4213,9 @@ namespace Profiler
                 {
                     bool selected = ( m_ResourceInspectorAccelerationStructure == accelerationStructure );
 
-                    // Acceleration structure types are a simple enum, convert to bitmask for filtering.
-                    VkFlags accelerationStructureTypeBit = ( 1U << accelerationStructureData.m_Type );
+                    // Convert acceleration structure type to bitmask for filtering.
+                    const VkProfilerAccelerationStructureTypeFlagsEXT accelerationStructureTypeBit =
+                        vkProfilerGetAccelerationStructureFlagsFromTypeEXT( accelerationStructureData.m_Type );
 
                     DrawResourceBrowserTableRow(
                         accelerationStructure,
@@ -4252,13 +4241,10 @@ namespace Profiler
                 {
                     bool selected = ( m_ResourceInspectorMicromap == micromap );
 
-                    // Micromap types are a simple enum, convert to bitmask for filtering.
-                    VkFlags micromapTypeBit = ( 1U << micromapData.m_Type );
-
                     DrawResourceBrowserTableRow(
                         micromap,
-                        micromapTypeBit,
-                        m_ResourceBrowserMicromapTypeFilter,
+                        VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_BIT_EXT,
+                        m_ResourceBrowserAccelerationStructureTypeFilter,
                         compareResult,
                         &selected );
 
@@ -5180,8 +5166,7 @@ namespace Profiler
                         m_pResourceListExporter->m_NameFilter,
                         m_pResourceListExporter->m_BufferUsageFilter,
                         m_pResourceListExporter->m_ImageUsageFilter,
-                        m_pResourceListExporter->m_AccelerationStructureTypeFilter,
-                        m_pResourceListExporter->m_MicromapTypeFilter );
+                        m_pResourceListExporter->m_AccelerationStructureTypeFilter );
                 }
 
                 // Destroy the exporter.
@@ -5204,8 +5189,7 @@ namespace Profiler
         const std::string& nameFilter,
         VkBufferUsageFlags bufferUsageFilter,
         VkImageUsageFlags imageUsageFilter,
-        VkFlags accelerationStructureTypeFilter,
-        VkFlags micromapTypeFilter )
+        VkFlags accelerationStructureTypeFilter )
     {
         DeviceProfilerCsvSerializer serializer;
 
@@ -5453,8 +5437,9 @@ namespace Profiler
 
                 for( const auto& [accelerationStructureHandle, accelerationStructure] : pData->m_Memory.m_AccelerationStructures )
                 {
-                    // Acceleration structure types are a simple enum, convert to bitmask for filtering.
-                    VkFlags accelerationStructureTypeBit = ( 1U << accelerationStructure.m_Type );
+                    // Convert acceleration structure type to bitmask for filtering.
+                    const VkProfilerAccelerationStructureTypeFlagsEXT accelerationStructureTypeBit =
+                        vkProfilerGetAccelerationStructureFlagsFromTypeEXT( accelerationStructure.m_Type );
 
                     const std::string accelerationStructureName = m_pStringSerializer->GetName( accelerationStructureHandle );
                     if( !FilterResourceByNameAndUsage( accelerationStructureName, accelerationStructureTypeBit, accelerationStructureTypeFilter ) )
@@ -5492,11 +5477,12 @@ namespace Profiler
 
                 for( const auto& [micromapHandle, micromap] : pData->m_Memory.m_Micromaps )
                 {
-                    // Micromap types are a simple enum, convert to bitmask for filtering.
-                    VkFlags micromapTypeBit = ( 1U << micromap.m_Type );
+                    // Convert micromap type to bitmask for filtering.
+                    const VkProfilerAccelerationStructureTypeFlagsEXT micromapTypeBit =
+                        VK_PROFILER_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_BIT_EXT;
 
                     const std::string micromapName = m_pStringSerializer->GetName( micromapHandle );
-                    if( !FilterResourceByNameAndUsage( micromapName, micromapTypeBit, micromapTypeFilter ) )
+                    if( !FilterResourceByNameAndUsage( micromapName, micromapTypeBit, accelerationStructureTypeFilter ) )
                     {
                         continue;
                     }

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.cpp
@@ -4056,7 +4056,7 @@ namespace Profiler
 
         ImGui::SameLine( 0, 10.f * interfaceScale );
         ResourceUsageFlagsFilterComboBox(
-            "Acceleration structures###AccelerationStructureFilter",
+            "Acceleration structures & Micromaps###AccelerationStructureFilter",
             m_ResourceBrowserAccelerationStructureTypeFilter,
             g_KnownAccelerationStructureTypes,
             &DeviceProfilerStringSerializer::GetAccelerationStructureTypeFlagNames );

--- a/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
+++ b/VkLayer_profiler_layer/profiler_overlay/profiler_overlay.h
@@ -41,6 +41,7 @@
 
 // Public interface
 #include "profiler_ext/VkProfilerEXT.h"
+#include "profiler_ext/VkProfilerCustomFlagsEXT.h"
 
 struct ImGuiContext;
 struct ImPlotContext;
@@ -248,7 +249,6 @@ namespace Profiler
         VkBufferUsageFlags m_ResourceBrowserBufferUsageFilter;
         VkImageUsageFlags m_ResourceBrowserImageUsageFilter;
         VkFlags m_ResourceBrowserAccelerationStructureTypeFilter;
-        VkFlags m_ResourceBrowserMicromapTypeFilter;
         bool m_ResourceBrowserShowDifferences;
 
         VkBufferHandle m_ResourceInspectorBuffer;
@@ -456,7 +456,7 @@ namespace Profiler
 
         std::string GetDefaultResourceListFileName() const;
         void UpdateResourceListExporter();
-        void SaveResourceListToFile( const std::string&, const std::shared_ptr<DeviceProfilerFrameData>&, const std::string&, VkBufferUsageFlags, VkImageUsageFlags, VkFlags, VkFlags );
+        void SaveResourceListToFile( const std::string&, const std::shared_ptr<DeviceProfilerFrameData>&, const std::string&, VkBufferUsageFlags, VkImageUsageFlags, VkProfilerAccelerationStructureTypeFlagsEXT );
 
         // Pipeline inspector helpers
         void Inspect( const DeviceProfilerPipeline& );

--- a/VkLayer_profiler_layer/profiler_tests/profiler_data_tests.cpp
+++ b/VkLayer_profiler_layer/profiler_tests/profiler_data_tests.cpp
@@ -44,6 +44,8 @@ void ExpectPNextChainEqual(
             const auto* pActualStructure =
                 Profiler::PNextChain( pActual )
                     .Find<VkAccelerationStructureGeometryMicromapDataKHR>( VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR );
+
+            ASSERT_NE( nullptr, pActualStructure );
             ExpectStructureEqual( *pExpectedStructure, *pActualStructure );
             break;
         }

--- a/VkLayer_profiler_layer/profiler_tests/profiler_data_tests.cpp
+++ b/VkLayer_profiler_layer/profiler_tests/profiler_data_tests.cpp
@@ -38,6 +38,15 @@ void ExpectPNextChainEqual(
     {
         switch( structure.sType )
         {
+        case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR:
+        {
+            const auto* pExpectedStructure = reinterpret_cast<const VkAccelerationStructureGeometryMicromapDataKHR*>( &structure );
+            const auto* pActualStructure =
+                Profiler::PNextChain( pActual )
+                    .Find<VkAccelerationStructureGeometryMicromapDataKHR>( VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR );
+            ExpectStructureEqual( *pExpectedStructure, *pActualStructure );
+            break;
+        }
         default:
         {
             break;
@@ -174,6 +183,66 @@ namespace Profiler
         VkAccelerationStructureBuildGeometryInfoKHR buildInfo = {};
         buildInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
         buildInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
+        buildInfo.flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+        buildInfo.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+        buildInfo.dstAccelerationStructure = VkObjectTraits<VkAccelerationStructureKHR>::GetObjectHandleAsVulkanHandle( 0x12345678 );
+        buildInfo.geometryCount = 1;
+        buildInfo.pGeometries = &geometry;
+
+        VkAccelerationStructureBuildRangeInfoKHR rangeInfo = {};
+        rangeInfo.primitiveCount = 1;
+        rangeInfo.primitiveOffset = 256;
+        rangeInfo.transformOffset = 1024;
+
+        VkAccelerationStructureBuildRangeInfoKHR* pRangeInfo = &rangeInfo;
+
+        DeviceProfilerDrawcallBuildAccelerationStructuresPayload payload = {};
+        payload.m_InfoCount = 1;
+        payload.m_pInfos = &buildInfo;
+        payload.m_ppRanges = &pRangeInfo;
+
+        DeviceProfilerDrawcallBuildAccelerationStructuresPayload copiedPayload = {};
+        copiedPayload.CopyDynamicAllocations( payload );
+
+        ASSERT_NE( nullptr, copiedPayload.m_pInfos );
+        ExpectStructureEqual( *payload.m_pInfos, *copiedPayload.m_pInfos );
+
+        ASSERT_NE( nullptr, copiedPayload.m_ppRanges );
+        for( uint32_t i = 0; i < payload.m_InfoCount; ++i )
+        {
+            const uint32_t geometryCount = payload.m_pInfos[i].geometryCount;
+            for( uint32_t j = 0; j < geometryCount; ++j )
+            {
+                ExpectStructureEqual( payload.m_ppRanges[i][j], copiedPayload.m_ppRanges[i][j] );
+            }
+        }
+
+        copiedPayload.FreeDynamicAllocations();
+    }
+
+    TEST( ProfilerDataULT, CopyAccelerationStructureBuildInfosWithMicromapData )
+    {
+        VkMicromapUsageKHR usageCount = {};
+        usageCount.count = 1;
+        usageCount.format = VK_OPACITY_MICROMAP_FORMAT_2_STATE_KHR;
+        usageCount.subdivisionLevel = 2;
+
+        VkAccelerationStructureGeometryMicromapDataKHR micromapData = {};
+        micromapData.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR;
+        micromapData.usageCountsCount = 1;
+        micromapData.pUsageCounts = &usageCount;
+        micromapData.data = 0x98765432;
+        micromapData.triangleArray = 0x87654321;
+        micromapData.triangleArrayStride = 64;
+
+        VkAccelerationStructureGeometryKHR geometry = {};
+        geometry.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+        geometry.pNext = &micromapData;
+        geometry.geometryType = VK_GEOMETRY_TYPE_MICROMAP_KHR;
+
+        VkAccelerationStructureBuildGeometryInfoKHR buildInfo = {};
+        buildInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+        buildInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_KHR;
         buildInfo.flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
         buildInfo.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
         buildInfo.dstAccelerationStructure = VkObjectTraits<VkAccelerationStructureKHR>::GetObjectHandleAsVulkanHandle( 0x12345678 );

--- a/VkLayer_profiler_layer/profiler_trace/profiler_json.cpp
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_json.cpp
@@ -386,17 +386,17 @@ namespace Profiler
                                 dataBuilder
                                     .Add( "usageCountsCount", pMicromapData->usageCountsCount );
 
-                                auto usageCountsBuilder = dataBuilder.AddArray( "usageCounts" );
-                                for( uint32_t k = 0; k < pMicromapData->usageCountsCount; ++k )
+                                if( auto usageCountsBuilder = dataBuilder.AddArrayOrNull( "usageCounts", pMicromapData->pUsageCounts || pMicromapData->ppUsageCounts ) )
                                 {
-                                    const auto& usageCount = pMicromapData->pUsageCounts[k];
-                                    usageCountsBuilder.AddObject()
-                                        .Add( "count", usageCount.count )
-                                        .Add( "format", usageCount.format )
-                                        .Add( "subdivisionLevel", usageCount.subdivisionLevel );
+                                    for( uint32_t k = 0; k < pMicromapData->usageCountsCount; ++k )
+                                    {
+                                        const auto& usageCount = ( pMicromapData->pUsageCounts ? pMicromapData->pUsageCounts[k] : *pMicromapData->ppUsageCounts[k] );
+                                        usageCountsBuilder.AddObject()
+                                            .Add( "count", usageCount.count )
+                                            .Add( "format", usageCount.format )
+                                            .Add( "subdivisionLevel", usageCount.subdivisionLevel );
+                                    }
                                 }
-
-                                usageCountsBuilder.End();
 
                                 dataBuilder
                                     .Add( "data", pMicromapData->data )

--- a/VkLayer_profiler_layer/profiler_trace/profiler_json.cpp
+++ b/VkLayer_profiler_layer/profiler_trace/profiler_json.cpp
@@ -374,6 +374,37 @@ namespace Profiler
                                 .Add( "arrayOfPointers", static_cast<bool>( geometry.geometry.instances.arrayOfPointers ) )
                                 .Add( "data", m_pStringSerializer->GetPointer( geometry.geometry.instances.data.hostAddress ) );
                             break;
+
+                        case VK_GEOMETRY_TYPE_MICROMAP_KHR:
+                        {
+                            const auto pMicromapData =
+                                PNextChain( geometry.pNext )
+                                    .Find<VkAccelerationStructureGeometryMicromapDataKHR>( VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MICROMAP_DATA_KHR );
+
+                            if( pMicromapData )
+                            {
+                                dataBuilder
+                                    .Add( "usageCountsCount", pMicromapData->usageCountsCount );
+
+                                auto usageCountsBuilder = dataBuilder.AddArray( "usageCounts" );
+                                for( uint32_t k = 0; k < pMicromapData->usageCountsCount; ++k )
+                                {
+                                    const auto& usageCount = pMicromapData->pUsageCounts[k];
+                                    usageCountsBuilder.AddObject()
+                                        .Add( "count", usageCount.count )
+                                        .Add( "format", usageCount.format )
+                                        .Add( "subdivisionLevel", usageCount.subdivisionLevel );
+                                }
+
+                                usageCountsBuilder.End();
+
+                                dataBuilder
+                                    .Add( "data", pMicromapData->data )
+                                    .Add( "triangleArray", pMicromapData->triangleArray )
+                                    .Add( "triangleArrayStride", pMicromapData->triangleArrayStride );
+                            }
+                            break;
+                        }
                         }
                         dataBuilder.End();
 


### PR DESCRIPTION
Provide micromap geometry data in the traces and show micromap acceleration structures correctly in the UI.
Merge filters for VkMicromapEXT and VkAccelerationStructureKHR objects as the KHR extension uses the latter to store the opacity micromaps.