### PR TITLE
Use additional command buffers to reset query pools.

### DIFF
--- a/VkLayer_profiler_layer/profiler/profiler.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler.cpp
@@ -1341,7 +1341,35 @@ namespace Profiler
     Description:
 
     \***********************************************************************************/
-    void DeviceProfiler::PreSubmitCommandBuffers( VkQueue queue )
+    auto DeviceProfiler::GetSubmitBatches( VkQueue queue, uint32_t count, const VkSubmitInfo* pSubmitInfos )
+        -> DeviceProfilerSubmitBatchesPerFrame
+    {
+        return GetSubmitBatchesImpl<VkSubmitInfo>( queue, count, pSubmitInfos );
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        PreSubmitCommandBuffers
+
+    Description:
+
+    \***********************************************************************************/
+    auto DeviceProfiler::GetSubmitBatches( VkQueue queue, uint32_t count, const VkSubmitInfo2* pSubmitInfos )
+        -> DeviceProfilerSubmitBatchesPerFrame
+    {
+        return GetSubmitBatchesImpl<VkSubmitInfo2>( queue, count, pSubmitInfos );
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        PreSubmitCommandBuffers
+
+    Description:
+
+    \***********************************************************************************/
+    void DeviceProfiler::PreSubmitCommandBuffers( VkQueue queue, DeviceProfilerSubmitBatchesPerFrame& submitBatchesPerFrame )
     {
         // Synchronize access to the queue if requested.
         if( m_Config.m_SynchronizeQueues )
@@ -1354,6 +1382,12 @@ namespace Profiler
         {
             m_pPerformanceCounters->SetQueuePerformanceConfiguration( queue );
         }
+
+        // Prepare command buffers for submission.
+        for( auto& [frameIndex, submitBatch] : submitBatchesPerFrame.m_FrameSubmitBatches )
+        {
+            m_DataAggregator.PrepareSubmit( submitBatch );
+        }
     }
 
     /***********************************************************************************\
@@ -1364,22 +1398,45 @@ namespace Profiler
     Description:
 
     \***********************************************************************************/
-    void DeviceProfiler::PostSubmitCommandBuffers( VkQueue queue, uint32_t count, const VkSubmitInfo* pSubmitInfo )
+    void DeviceProfiler::PostSubmitCommandBuffers( VkQueue queue, DeviceProfilerSubmitBatchesPerFrame& submitBatchesPerFrame )
     {
-        PostSubmitCommandBuffersImpl<VkSubmitInfo>( queue, count, pSubmitInfo );
-    }
+        TipRangeId tip = m_pDevice->TIP.BeginFunction( __func__ );
 
-    /***********************************************************************************\
+        // Append the submit batches for aggregation.
+        for( auto& [frameIndex, submitBatch] : submitBatchesPerFrame.m_FrameSubmitBatches )
+        {
+            m_DataAggregator.AppendSubmit( frameIndex, submitBatch );
+        }
 
-    Function:
-        PostSubmitCommandBuffers
+        // Delimit frames if needed.
+        if( m_Config.m_FrameDelimiter == frame_delimiter_t::submit )
+        {
+            m_DataAggregator.EndFrame( m_FrameIndex );
+            m_FrameIndex++;
+        }
 
-    Description:
+        if( m_Config.m_FrameDelimiter == frame_delimiter_t::frame_boundary_ext )
+        {
+            for( uint32_t frameIndex : submitBatchesPerFrame.m_FrameEndedIndices )
+            {
+                m_DataAggregator.EndFrame( frameIndex );
+            }
+        }
 
-    \***********************************************************************************/
-    void DeviceProfiler::PostSubmitCommandBuffers( VkQueue queue, uint32_t count, const VkSubmitInfo2* pSubmitInfo )
-    {
-        PostSubmitCommandBuffersImpl<VkSubmitInfo2>( queue, count, pSubmitInfo );
+        // If synchronization between queues is enabled, wait with the mutex locked to ensure it is completed before the next submission.
+        if( m_Config.m_SynchronizeQueues )
+        {
+            m_pDevice->Callbacks.QueueWaitIdle( queue );
+        }
+
+        // Get data captured during the last frame
+        ResolveFrameData( tip );
+
+        // Release the lock acquired in PreSubmitCommandBuffers.
+        if( m_Config.m_SynchronizeQueues )
+        {
+            m_SubmitMutex.unlock();
+        }
     }
 
     /***********************************************************************************\
@@ -1391,7 +1448,8 @@ namespace Profiler
 
     \***********************************************************************************/
     template<typename SubmitInfoT>
-    void DeviceProfiler::PostSubmitCommandBuffersImpl( VkQueue queue, uint32_t submitCount, const SubmitInfoT* pSubmits )
+    auto DeviceProfiler::GetSubmitBatchesImpl( VkQueue queue, uint32_t submitCount, const SubmitInfoT* pSubmits )
+        -> DeviceProfilerSubmitBatchesPerFrame
     {
         using T = SubmitInfoTraits<SubmitInfoT>;
 
@@ -1399,9 +1457,7 @@ namespace Profiler
 
         // Applications can issue submissions belonging to different frames in a single call.
         // Split those submissions into separate batches.
-        std::unordered_map<uint32_t, DeviceProfilerSubmitBatch> submitBatches;
-        // List of frames that ended during this submission.
-        std::vector<uint32_t> frameBoundaryExtEndedFrames;
+        DeviceProfilerSubmitBatchesPerFrame submitBatchesPerFrame;
 
         const uint64_t timestamp = m_CpuTimestampCounter.GetCurrentValue();
         const uint32_t threadId = ProfilerPlatformFunctions::GetCurrentThreadId();
@@ -1428,16 +1484,16 @@ namespace Profiler
 
                     if( pFrameBoundary->flags & VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT )
                     {
-                        frameBoundaryExtEndedFrames.push_back( submitFrameIndex );
+                        submitBatchesPerFrame.m_FrameEndedIndices.push_back( submitFrameIndex );
                     }
                 }
             }
 
             // Get submit batch associated with the frame index of the submission.
-            auto it = submitBatches.find( submitFrameIndex );
-            if( it == submitBatches.end() )
+            auto it = submitBatchesPerFrame.m_FrameSubmitBatches.find( submitFrameIndex );
+            if( it == submitBatchesPerFrame.m_FrameSubmitBatches.end() )
             {
-                it = submitBatches.emplace( submitFrameIndex, DeviceProfilerSubmitBatch{} ).first;
+                it = submitBatchesPerFrame.m_FrameSubmitBatches.emplace( submitFrameIndex, DeviceProfilerSubmitBatch{} ).first;
                 it->second.m_Handle = ResolveObjectHandle<VkQueueHandle>( queue );
                 it->second.m_Timestamp = timestamp;
                 it->second.m_ThreadId = threadId;
@@ -1461,6 +1517,15 @@ namespace Profiler
                 pProfilerCommandBuffer->Submit();
 
                 submit.m_pCommandBuffers.push_back( pProfilerCommandBuffer );
+
+                // Save the command buffer, and its secondary command buffer pointers in the global set
+                const std::unordered_set<ProfilerCommandBuffer*>& pSecondaryCommandBuffers =
+                    pProfilerCommandBuffer->GetSecondaryCommandBuffers();
+
+                submitBatch.m_pSubmittedCommandBuffers.insert( pProfilerCommandBuffer );
+                submitBatch.m_pSubmittedCommandBuffers.insert(
+                    pSecondaryCommandBuffers.begin(),
+                    pSecondaryCommandBuffers.end() );
             }
 
             // Copy semaphores
@@ -1477,41 +1542,7 @@ namespace Profiler
             }
         }
 
-        // Append the submit batches for aggregation.
-        for( const auto& [frameIndex, submitBatch] : submitBatches )
-        {
-            m_DataAggregator.AppendSubmit( frameIndex, submitBatch );
-        }
-
-        // Delimit frames if needed.
-        if( m_Config.m_FrameDelimiter == frame_delimiter_t::submit )
-        {
-            m_DataAggregator.EndFrame( m_FrameIndex );
-            m_FrameIndex++;
-        }
-
-        if( m_Config.m_FrameDelimiter == frame_delimiter_t::frame_boundary_ext )
-        {
-            for( uint32_t frameIndex : frameBoundaryExtEndedFrames )
-            {
-                m_DataAggregator.EndFrame( frameIndex );
-            }
-        }
-
-        // If synchronization between queues is enabled, wait with the mutex locked to ensure it is completed before the next submission.
-        if( m_Config.m_SynchronizeQueues )
-        {
-            m_pDevice->Callbacks.QueueWaitIdle( queue );
-        }
-
-        // Get data captured during the last frame
-        ResolveFrameData( tip );
-
-        // Release the lock acquired in PreSubmitCommandBuffers.
-        if( m_Config.m_SynchronizeQueues )
-        {
-            m_SubmitMutex.unlock();
-        }
+        return submitBatchesPerFrame;
     }
 
     /***********************************************************************************\

--- a/VkLayer_profiler_layer/profiler/profiler.h
+++ b/VkLayer_profiler_layer/profiler/profiler.h
@@ -122,9 +122,10 @@ namespace Profiler
         void CreateRenderPass( VkRenderPass, const VkRenderPassCreateInfo2* );
         void DestroyRenderPass( VkRenderPass );
 
-        void PreSubmitCommandBuffers( VkQueue );
-        void PostSubmitCommandBuffers( VkQueue, uint32_t, const VkSubmitInfo* );
-        void PostSubmitCommandBuffers( VkQueue, uint32_t, const VkSubmitInfo2* );
+        auto GetSubmitBatches( VkQueue, uint32_t, const VkSubmitInfo* ) -> DeviceProfilerSubmitBatchesPerFrame;
+        auto GetSubmitBatches( VkQueue, uint32_t, const VkSubmitInfo2* ) -> DeviceProfilerSubmitBatchesPerFrame;
+        void PreSubmitCommandBuffers( VkQueue, DeviceProfilerSubmitBatchesPerFrame& );
+        void PostSubmitCommandBuffers( VkQueue, DeviceProfilerSubmitBatchesPerFrame& );
 
         void FinishFrame();
         void FinishFrame( const VkPresentInfoKHR* );
@@ -220,7 +221,7 @@ namespace Profiler
         decltype(m_pCommandBuffers)::iterator FreeCommandBuffer( decltype(m_pCommandBuffers)::iterator );
 
         template<typename SubmitInfoT>
-        void PostSubmitCommandBuffersImpl( VkQueue, uint32_t, const SubmitInfoT* );
+        auto GetSubmitBatchesImpl( VkQueue, uint32_t, const SubmitInfoT* ) -> DeviceProfilerSubmitBatchesPerFrame;
 
         void ResolveFrameData( TipRangeId& tip );
 

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.cpp
@@ -1059,6 +1059,28 @@ namespace Profiler
     /***********************************************************************************\
 
     Function:
+        ResetQueryPools
+
+    Description:
+        Reset all query pools before the next profiling run using the provided command buffer.
+
+    \***********************************************************************************/
+    void ProfilerCommandBuffer::ResetQueryPools( VkCommandBuffer commandBuffer ) const
+    {
+        if( m_ProfilingEnabled )
+        {
+            m_pQueryPool->ResetQueryPools( commandBuffer );
+
+            for( ProfilerCommandBuffer* pSecondaryCommandBuffer : m_pSecondaryCommandBuffers )
+            {
+                pSecondaryCommandBuffer->ResetQueryPools( commandBuffer );
+            }
+        }
+    }
+
+    /***********************************************************************************\
+
+    Function:
         GetSecondaryCommandBuffers
 
     Description:

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer.h
@@ -87,6 +87,7 @@ namespace Profiler
 
         uint64_t GetRequiredQueryDataBufferSize() const;
         void WriteQueryData( DeviceProfilerQueryDataBufferWriter& ) const;
+        void ResetQueryPools( VkCommandBuffer ) const;
 
         const std::unordered_set<ProfilerCommandBuffer*>& GetSecondaryCommandBuffers() const;
 

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.cpp
@@ -161,24 +161,6 @@ namespace Profiler
     {
         TipGuard tip( m_Profiler.m_pDevice->TIP, __func__ );
 
-        // Reset the full query pools.
-        for( uint32_t queryPoolIndex = 0; queryPoolIndex < m_CurrentQueryPoolIndex; ++queryPoolIndex )
-        {
-            m_Device.Callbacks.CmdResetQueryPool(
-                commandBuffer,
-                m_QueryPools[ queryPoolIndex ],
-                0, m_QueryPoolSize );
-        }
-
-        // Reset the last query pool.
-        if( m_CurrentQueryIndex != UINT32_MAX )
-        {
-            m_Device.Callbacks.CmdResetQueryPool(
-                commandBuffer,
-                m_QueryPools[ m_CurrentQueryPoolIndex ],
-                0, (m_CurrentQueryIndex + 1) );
-        }
-
         m_AbsQueryIndex = UINT64_MAX;
         m_CurrentQueryIndex = UINT32_MAX;
         m_CurrentQueryPoolIndex = 0;
@@ -293,6 +275,36 @@ namespace Profiler
     /***********************************************************************************\
 
     Function:
+        ResetQueryPools
+
+    Description:
+        Resets the query pools.
+
+    \***********************************************************************************/
+    void CommandBufferQueryPool::ResetQueryPools( VkCommandBuffer commandBuffer ) const
+    {
+        // Reset the full query pools.
+        for( uint32_t queryPoolIndex = 0; queryPoolIndex < m_CurrentQueryPoolIndex; ++queryPoolIndex )
+        {
+            m_Device.Callbacks.CmdResetQueryPool(
+                commandBuffer,
+                m_QueryPools[queryPoolIndex],
+                0, m_QueryPoolSize );
+        }
+
+        // Reset the last query pool.
+        if( m_CurrentQueryIndex != UINT32_MAX )
+        {
+            m_Device.Callbacks.CmdResetQueryPool(
+                commandBuffer,
+                m_QueryPools[m_CurrentQueryPoolIndex],
+                0, ( m_CurrentQueryIndex + 1 ) );
+        }
+    }
+
+    /***********************************************************************************\
+
+    Function:
         WriteTimestamp
 
     Description:
@@ -358,9 +370,6 @@ namespace Profiler
         {
             assert( queryPool != VK_NULL_HANDLE );
             m_QueryPools.push_back( queryPool );
-
-            // Pools must be reset before first use
-            m_Device.Callbacks.CmdResetQueryPool( commandBuffer, queryPool, 0, m_QueryPoolSize );
         }
     }
 

--- a/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.h
+++ b/VkLayer_profiler_layer/profiler/profiler_command_buffer_query_pool.h
@@ -64,6 +64,7 @@ namespace Profiler
         void EndPerformanceQuery( VkCommandBuffer commandBuffer );
 
         void WriteQueryData( DeviceProfilerQueryDataBufferWriter& writer ) const;
+        void ResetQueryPools( VkCommandBuffer commandBuffer ) const;
 
         uint64_t WriteTimestamp( VkCommandBuffer commandBuffer, VkPipelineStageFlagBits stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT );
 

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.cpp
@@ -322,46 +322,40 @@ namespace Profiler
     /***********************************************************************************\
 
     Function:
+        PrepareSubmit
+
+    Description:
+        Prepare submit batch for execution.
+
+    \***********************************************************************************/
+    void ProfilerDataAggregator::PrepareSubmit( DeviceProfilerSubmitBatch& submitBatch )
+    {
+        TipGuard tip( m_pProfiler->m_pDevice->TIP, __func__ );
+
+        // Get the command pool associated with the queue.
+        submitBatch.m_pInternalCommandPool = &m_CopyCommandPools.at( submitBatch.m_Handle );
+
+        // Reset all query pools used in this submit batch.
+        bool succeeded = ResetQueryPools( submitBatch );
+        if( !succeeded )
+        {
+            FreeDynamicAllocations( submitBatch );
+            return;
+        }
+    }
+
+    /***********************************************************************************\
+
+    Function:
         AppendSubmit
 
     Description:
         Add submit data to the aggregator.
 
     \***********************************************************************************/
-    void ProfilerDataAggregator::AppendSubmit( uint32_t frameIndex, const DeviceProfilerSubmitBatch& submit )
+    void ProfilerDataAggregator::AppendSubmit( uint32_t frameIndex, DeviceProfilerSubmitBatch& submitBatch )
     {
         TipGuard tip( m_pProfiler->m_pDevice->TIP, __func__ );
-
-        // Prepare submit batch info.
-        SubmitBatch submitBatch( submit );
-
-        for( const DeviceProfilerSubmit& _submit : submitBatch.m_Submits )
-        {
-            submitBatch.m_pSubmittedCommandBuffers.insert(
-                _submit.m_pCommandBuffers.begin(),
-                _submit.m_pCommandBuffers.end() );
-
-            // Track secondary command buffers as well.
-            for( const ProfilerCommandBuffer* pCommandBuffer : _submit.m_pCommandBuffers )
-            {
-                const std::unordered_set<ProfilerCommandBuffer*>& pSecondaryCommandBuffers =
-                    pCommandBuffer->GetSecondaryCommandBuffers();
-
-                submitBatch.m_pSubmittedCommandBuffers.insert(
-                    pSecondaryCommandBuffers.begin(),
-                    pSecondaryCommandBuffers.end() );
-            }
-        }
-
-        // Allocate a buffer for the query data.
-        uint64_t bufferSize = 0;
-
-        for( const ProfilerCommandBuffer* pCommandBuffer : submitBatch.m_pSubmittedCommandBuffers )
-        {
-            bufferSize += pCommandBuffer->GetRequiredQueryDataBufferSize();
-        }
-
-        submitBatch.m_pDataBuffer = new DeviceProfilerQueryDataBuffer( *m_pProfiler, bufferSize );
 
         // Try to copy the data using GPU.
         // It may fallback to CPU allocation if the function fails to allocate the command buffer.
@@ -380,8 +374,8 @@ namespace Profiler
         {
             pFrame = std::make_shared<Frame>();
             pFrame->m_FrameIndex = frameIndex;
-            pFrame->m_ThreadId = submit.m_ThreadId;
-            pFrame->m_Timestamp = submit.m_Timestamp;
+            pFrame->m_ThreadId = submitBatch.m_ThreadId;
+            pFrame->m_Timestamp = submitBatch.m_Timestamp;
             pFrame->m_FramesPerSec = m_pProfiler->m_CpuFpsCounter.GetValue();
             pFrame->m_FrameDelimiter = static_cast<VkProfilerFrameDelimiterEXT>( m_pProfiler->m_Config.m_FrameDelimiter.value );
             pFrame->m_SyncTimestamps = m_pProfiler->GetSynchronizationTimestamps();
@@ -393,9 +387,9 @@ namespace Profiler
         submitBatch.m_SubmitBatchDataIndex = static_cast<uint32_t>( frame.m_CompleteSubmits.size() );
 
         DeviceProfilerSubmitBatchData& submitBatchData = frame.m_CompleteSubmits.emplace_back();
-        submitBatchData.m_Handle = submit.m_Handle;
-        submitBatchData.m_ThreadId = submit.m_ThreadId;
-        submitBatchData.m_Timestamp = submit.m_Timestamp;
+        submitBatchData.m_Handle = submitBatch.m_Handle;
+        submitBatchData.m_ThreadId = submitBatch.m_ThreadId;
+        submitBatchData.m_Timestamp = submitBatch.m_Timestamp;
 
         // Append the submit to the last frame in the queue.
         frame.m_PendingSubmits.push_back( std::move( submitBatch ) );
@@ -480,7 +474,7 @@ namespace Profiler
             // Wait for all pending submits that reference the command buffer.
             for( const std::shared_ptr<Frame>& pFrame : m_pPendingFrames )
             {
-                for( const SubmitBatch& submitBatch : pFrame->m_PendingSubmits )
+                for( const DeviceProfilerSubmitBatch& submitBatch : pFrame->m_PendingSubmits )
                 {
                     if( submitBatch.m_pSubmittedCommandBuffers.count( pWaitForCommandBuffer ) )
                     {
@@ -652,7 +646,7 @@ namespace Profiler
 
     \***********************************************************************************/
     void ProfilerDataAggregator::ResolveSubmitBatchData(
-        SubmitBatch& submitBatch,
+        DeviceProfilerSubmitBatch& submitBatch,
         DeviceProfilerSubmitBatchData& submitBatchData ) const
     {
         TipGuard tip( m_pProfiler->m_pDevice->TIP, __func__ );
@@ -1293,7 +1287,7 @@ namespace Profiler
         Frees all dynamic allocations of the submit batch.
 
     \***********************************************************************************/
-    void ProfilerDataAggregator::FreeDynamicAllocations( SubmitBatch& submitBatch )
+    void ProfilerDataAggregator::FreeDynamicAllocations( DeviceProfilerSubmitBatch& submitBatch )
     {
         if( submitBatch.m_DataCopyFence )
         {
@@ -1301,19 +1295,121 @@ namespace Profiler
                 m_pProfiler->m_pDevice->Handle,
                 submitBatch.m_DataCopyFence,
                 nullptr );
+
+            submitBatch.m_DataCopyFence = VK_NULL_HANDLE;
         }
-        if( submitBatch.m_DataCopyCommandBuffer )
+
+        if( submitBatch.m_QueryResetCommandBuffer )
         {
-            assert( submitBatch.m_pDataCopyCommandPool != nullptr );
-            std::unique_lock commandPoolLock( submitBatch.m_pDataCopyCommandPool->GetMutex() );
+            assert( submitBatch.m_pInternalCommandPool != nullptr );
+            std::unique_lock commandPoolLock( submitBatch.m_pInternalCommandPool->GetMutex() );
 
             m_pProfiler->m_pDevice->Callbacks.FreeCommandBuffers(
                 m_pProfiler->m_pDevice->Handle,
-                submitBatch.m_pDataCopyCommandPool->GetHandle(),
-                1, &submitBatch.m_DataCopyCommandBuffer );
+                submitBatch.m_pInternalCommandPool->GetHandle(),
+                1, &submitBatch.m_QueryResetCommandBuffer );
+
+            submitBatch.m_QueryResetCommandBuffer = VK_NULL_HANDLE;
         }
 
+        if( submitBatch.m_DataCopyCommandBuffer )
+        {
+            assert( submitBatch.m_pInternalCommandPool != nullptr );
+            std::unique_lock commandPoolLock( submitBatch.m_pInternalCommandPool->GetMutex() );
+
+            m_pProfiler->m_pDevice->Callbacks.FreeCommandBuffers(
+                m_pProfiler->m_pDevice->Handle,
+                submitBatch.m_pInternalCommandPool->GetHandle(),
+                1, &submitBatch.m_DataCopyCommandBuffer );
+
+            submitBatch.m_DataCopyCommandBuffer = VK_NULL_HANDLE;
+        }
+
+        submitBatch.m_pInternalCommandPool = nullptr;
+
         delete submitBatch.m_pDataBuffer;
+        submitBatch.m_pDataBuffer = nullptr;
+    }
+
+    /***********************************************************************************\
+
+    Function:
+        ResetQueryPools
+
+    Description:
+        Allocate a command buffer, record reset commands and submit it for execution.
+
+    \***********************************************************************************/
+    bool ProfilerDataAggregator::ResetQueryPools( DeviceProfilerSubmitBatch& submitBatch )
+    {
+        // Synchronize access to the command pool.
+        std::unique_lock commandPoolLock( submitBatch.m_pInternalCommandPool->GetMutex() );
+
+        // Allocate the command buffer.
+        VkCommandBufferAllocateInfo commandBufferAllocateInfo = {};
+        commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        commandBufferAllocateInfo.commandBufferCount = 1;
+        commandBufferAllocateInfo.commandPool = submitBatch.m_pInternalCommandPool->GetHandle();
+
+        VkResult result = m_pProfiler->m_pDevice->Callbacks.AllocateCommandBuffers(
+            m_pProfiler->m_pDevice->Handle,
+            &commandBufferAllocateInfo,
+            &submitBatch.m_QueryResetCommandBuffer );
+
+        if( result == VK_SUCCESS )
+        {
+            // Command buffers are dispatchable handles, update pointers to parent's dispatch table.
+            result = m_pProfiler->m_pDevice->SetDeviceLoaderData(
+                m_pProfiler->m_pDevice->Handle,
+                submitBatch.m_QueryResetCommandBuffer );
+        }
+
+        if( result == VK_SUCCESS )
+        {
+            // Begin recording commands to the copy command buffer.
+            VkCommandBufferBeginInfo commandBufferBeginInfo = {};
+            commandBufferBeginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            commandBufferBeginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+            result = m_pProfiler->m_pDevice->Callbacks.BeginCommandBuffer(
+                submitBatch.m_QueryResetCommandBuffer,
+                &commandBufferBeginInfo );
+        }
+
+        if( result == VK_SUCCESS )
+        {
+            // Reset all query pools on the GPU.
+            for( ProfilerCommandBuffer* pCommandBuffer : submitBatch.m_pSubmittedCommandBuffers )
+            {
+                pCommandBuffer->ResetQueryPools( submitBatch.m_QueryResetCommandBuffer );
+            }
+
+            result = m_pProfiler->m_pDevice->Callbacks.EndCommandBuffer(
+                submitBatch.m_QueryResetCommandBuffer );
+        }
+
+        if( result == VK_SUCCESS )
+        {
+            // Submit the command buffer for execution.
+            VkSubmitInfo submitInfo = {};
+            submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            submitInfo.commandBufferCount = 1;
+            submitInfo.pCommandBuffers = &submitBatch.m_QueryResetCommandBuffer;
+
+            result = m_pProfiler->m_pDevice->Callbacks.QueueSubmit(
+                submitBatch.m_Handle,
+                1,
+                &submitInfo,
+                VK_NULL_HANDLE );
+        }
+
+        if( result != VK_SUCCESS )
+        {
+            // todo: Reset using host.
+        }
+
+        return ( result == VK_SUCCESS );
     }
 
     /***********************************************************************************\
@@ -1326,29 +1422,35 @@ namespace Profiler
         Fallback to a CPU allocation if the allocation or recording fails.
 
     \***********************************************************************************/
-    bool ProfilerDataAggregator::WriteQueryDataToGpuBuffer( SubmitBatch& submitBatch )
+    bool ProfilerDataAggregator::WriteQueryDataToGpuBuffer( DeviceProfilerSubmitBatch& submitBatch )
     {
         // Always submit the fence to GPU to check for data availability later.
         uint32_t submitCount = 0;
         VkSubmitInfo submitInfo = {};
         submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
+        // Allocate a buffer for the query data.
+        uint64_t bufferSize = 0;
+
+        for( const ProfilerCommandBuffer* pCommandBuffer : submitBatch.m_pSubmittedCommandBuffers )
+        {
+            bufferSize += pCommandBuffer->GetRequiredQueryDataBufferSize();
+        }
+
+        submitBatch.m_pDataBuffer = new DeviceProfilerQueryDataBuffer( *m_pProfiler, bufferSize );
+
         // Try to copy using GPU if allocation is available.
         if( submitBatch.m_pDataBuffer->UsesGpuAllocation() )
         {
-            // Get the command pool associated with the queue.
-            DeviceProfilerInternalCommandPool& commandPool = m_CopyCommandPools.at( submitBatch.m_Handle );
-            submitBatch.m_pDataCopyCommandPool = &commandPool;
-
             // Synchronize access to the command pool.
-            std::unique_lock commandPoolLock( commandPool.GetMutex() );
+            std::unique_lock commandPoolLock( submitBatch.m_pInternalCommandPool->GetMutex() );
 
             // Allocate the command buffer.
             VkCommandBufferAllocateInfo commandBufferAllocateInfo = {};
             commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
             commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
             commandBufferAllocateInfo.commandBufferCount = 1;
-            commandBufferAllocateInfo.commandPool = commandPool.GetHandle();
+            commandBufferAllocateInfo.commandPool = submitBatch.m_pInternalCommandPool->GetHandle();
 
             VkResult result = m_pProfiler->m_pDevice->Callbacks.AllocateCommandBuffers(
                 m_pProfiler->m_pDevice->Handle,
@@ -1439,7 +1541,7 @@ namespace Profiler
         Copy the data from the query pools to the buffer.
 
     \***********************************************************************************/
-    bool ProfilerDataAggregator::WriteQueryDataToCpuBuffer( SubmitBatch& submitBatch )
+    bool ProfilerDataAggregator::WriteQueryDataToCpuBuffer( DeviceProfilerSubmitBatch& submitBatch )
     {
         // Drop the packet if the CPU buffer allocation failed.
         if( submitBatch.m_pDataBuffer->GetCpuBuffer() == nullptr )

--- a/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
+++ b/VkLayer_profiler_layer/profiler/profiler_data_aggregator.h
@@ -49,6 +49,22 @@ namespace Profiler
         ContainerType<DeviceProfilerSubmit>             m_Submits = {};
         uint64_t                                        m_Timestamp = {};
         uint32_t                                        m_ThreadId = {};
+
+        DeviceProfilerQueryDataBuffer*                  m_pDataBuffer = {};
+
+        DeviceProfilerInternalCommandPool*              m_pInternalCommandPool = {};
+        VkCommandBuffer                                 m_QueryResetCommandBuffer  = {};
+        VkCommandBuffer                                 m_DataCopyCommandBuffer = {};
+        VkFence                                         m_DataCopyFence = {};
+
+        uint32_t                                        m_SubmitBatchDataIndex = 0;
+        std::unordered_set<ProfilerCommandBuffer*>      m_pSubmittedCommandBuffers = {};
+    };
+
+    struct DeviceProfilerSubmitBatchesPerFrame
+    {
+        std::unordered_map<uint32_t, DeviceProfilerSubmitBatch> m_FrameSubmitBatches = {};
+        std::vector<uint32_t>                           m_FrameEndedIndices = {};
     };
 
     /***********************************************************************************\
@@ -62,22 +78,6 @@ namespace Profiler
     \***********************************************************************************/
     class ProfilerDataAggregator
     {
-        struct SubmitBatch : DeviceProfilerSubmitBatch
-        {
-            DeviceProfilerQueryDataBuffer*              m_pDataBuffer = {};
-
-            DeviceProfilerInternalCommandPool*          m_pDataCopyCommandPool = {};
-            VkCommandBuffer                             m_DataCopyCommandBuffer = {};
-            VkFence                                     m_DataCopyFence = {};
-
-            uint32_t                                    m_SubmitBatchDataIndex = 0;
-            std::unordered_set<ProfilerCommandBuffer*>  m_pSubmittedCommandBuffers = {};
-
-            SubmitBatch( const DeviceProfilerSubmitBatch& submitBatch )
-                : DeviceProfilerSubmitBatch( submitBatch )
-            {}
-        };
-
         struct Frame
         {
             uint32_t                                    m_FrameIndex = 0;
@@ -87,7 +87,7 @@ namespace Profiler
             VkProfilerFrameDelimiterEXT                 m_FrameDelimiter = {};
             DeviceProfilerSynchronizationTimestamps     m_SyncTimestamps = {};
 
-            std::list<SubmitBatch>                      m_PendingSubmits = {};
+            std::list<DeviceProfilerSubmitBatch>        m_PendingSubmits = {};
             std::deque<DeviceProfilerSubmitBatchData>   m_CompleteSubmits = {};
 
             uint64_t                                    m_EndTimestamp = {};
@@ -106,7 +106,8 @@ namespace Profiler
         bool IsDataCollectionThreadRunning() const { return m_DataCollectionThreadRunning; }
         void StopDataCollectionThread();
 
-        void AppendSubmit( uint32_t, const DeviceProfilerSubmitBatch& );
+        void PrepareSubmit( DeviceProfilerSubmitBatch& );
+        void AppendSubmit( uint32_t, DeviceProfilerSubmitBatch& );
         void EndFrame( uint32_t );
         void EndPendingFrames();
 
@@ -143,11 +144,12 @@ namespace Profiler
         void CollectPipelinesFromCommandBuffer( const DeviceProfilerCommandBufferData&, std::unordered_map<uint32_t, DeviceProfilerPipelineData>& ) const;
         void CollectPipeline( const DeviceProfilerPipelineData&, std::unordered_map<uint32_t, DeviceProfilerPipelineData>&, std::unordered_map<uint32_t, std::pair<uint64_t, uint64_t>>& ) const;
 
-        void ResolveSubmitBatchData( SubmitBatch&, DeviceProfilerSubmitBatchData& ) const;
+        void ResolveSubmitBatchData( DeviceProfilerSubmitBatch&, DeviceProfilerSubmitBatchData& ) const;
         void ResolveFrameData( Frame&, DeviceProfilerFrameData& ) const;
 
-        void FreeDynamicAllocations( SubmitBatch& );
-        bool WriteQueryDataToGpuBuffer( SubmitBatch& );
-        bool WriteQueryDataToCpuBuffer( SubmitBatch& );
+        void FreeDynamicAllocations( DeviceProfilerSubmitBatch& );
+        bool ResetQueryPools( DeviceProfilerSubmitBatch& );
+        bool WriteQueryDataToGpuBuffer( DeviceProfilerSubmitBatch& );
+        bool WriteQueryDataToCpuBuffer( DeviceProfilerSubmitBatch& );
     };
 }

--- a/VkLayer_profiler_layer/profiler_layer_functions/core/VkQueue_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/core/VkQueue_functions.cpp
@@ -42,12 +42,14 @@ namespace Profiler
         // Synchronize host access to the queue object in case the overlay tries to use it.
         VkQueue_Object_Scope queueScope( dd.Device.Queues.at( queue ) );
 
-        dd.Profiler.PreSubmitCommandBuffers( queue );
+        DeviceProfilerSubmitBatchesPerFrame submitBatchesPerFrame =
+            dd.Profiler.GetSubmitBatches( queue, submitCount, pSubmits );
+        dd.Profiler.PreSubmitCommandBuffers( queue, submitBatchesPerFrame );
 
         // Submit the command buffers
         VkResult result = dd.Device.Callbacks.QueueSubmit( queue, submitCount, pSubmits, fence );
 
-        dd.Profiler.PostSubmitCommandBuffers( queue, submitCount, pSubmits );
+        dd.Profiler.PostSubmitCommandBuffers( queue, submitBatchesPerFrame );
 
         // Consume the collected data
         if( dd.pOutput )
@@ -78,12 +80,14 @@ namespace Profiler
         // Synchronize host access to the queue object in case the overlay tries to use it.
         VkQueue_Object_Scope queueScope( dd.Device.Queues.at( queue ) );
 
-        dd.Profiler.PreSubmitCommandBuffers( queue );
+        DeviceProfilerSubmitBatchesPerFrame submitBatchesPerFrame =
+            dd.Profiler.GetSubmitBatches( queue, submitCount, pSubmits );
+        dd.Profiler.PreSubmitCommandBuffers( queue, submitBatchesPerFrame );
 
         // Submit the command buffers
         VkResult result = dd.Device.Callbacks.QueueSubmit2( queue, submitCount, pSubmits, fence );
 
-        dd.Profiler.PostSubmitCommandBuffers( queue, submitCount, pSubmits );
+        dd.Profiler.PostSubmitCommandBuffers( queue, submitBatchesPerFrame );
 
         // Consume the collected data
         if( dd.pOutput )

--- a/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkSynchronization2Khr_functions.cpp
+++ b/VkLayer_profiler_layer/profiler_layer_functions/extensions/VkSynchronization2Khr_functions.cpp
@@ -42,12 +42,14 @@ namespace Profiler
         // Synchronize host access to the queue object in case the overlay tries to use it.
         VkQueue_Object_Scope queueScope( dd.Device.Queues.at( queue ) );
 
-        dd.Profiler.PreSubmitCommandBuffers( queue );
+        DeviceProfilerSubmitBatchesPerFrame submitBatchesPerFrame =
+            dd.Profiler.GetSubmitBatches( queue, submitCount, pSubmits );
+        dd.Profiler.PreSubmitCommandBuffers( queue, submitBatchesPerFrame );
 
         // Submit the command buffers
         VkResult result = dd.Device.Callbacks.QueueSubmit2KHR( queue, submitCount, pSubmits, fence );
 
-        dd.Profiler.PostSubmitCommandBuffers( queue, submitCount, pSubmits );
+        dd.Profiler.PostSubmitCommandBuffers( queue, submitBatchesPerFrame );
 
         // Consume the collected data
         if( dd.Profiler.m_Config.m_FrameDelimiter == VK_PROFILER_FRAME_DELIMITER_SUBMIT_EXT )


### PR DESCRIPTION
Decoupling query pool resets from the profiled command buffers allows to dynamically allocate the pools inside render passes, and later suballocate and reuse them between multiple command buffers.